### PR TITLE
Fix whitespace parsing, with enhanced parser debugging

### DIFF
--- a/packages/stylist-core/src/parser.rs
+++ b/packages/stylist-core/src/parser.rs
@@ -935,6 +935,73 @@ mod tests {
     }
 
     #[test]
+    fn test_dense_style() {
+        init();
+        let test_str = r#"@media print{color:black;.nested{cursor:none;}}"#;
+        let parsed = Parser::parse(test_str).expect("Failed to Parse Style");
+
+        let expected = Sheet::from(vec![ScopeContent::Rule(Rule {
+            condition: vec!["@media ".into(), "print".into()].into(),
+            content: vec![
+                RuleContent::Block(Block {
+                    condition: vec![].into(),
+                    style_attributes: vec![StyleAttribute {
+                        key: "color".into(),
+                        value: vec!["black".into()].into(),
+                    }]
+                    .into(),
+                }),
+                RuleContent::Block(Block {
+                    condition: vec![vec![".nested".into()].into()].into(),
+                    style_attributes: vec![StyleAttribute {
+                        key: "cursor".into(),
+                        value: vec!["none".into()].into(),
+                    }]
+                    .into(),
+                }),
+            ]
+            .into(),
+        })]);
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn test_issue_36() {
+        init();
+        let test_str = r#"
+  position: fixed; /* Stay in place */
+  z-index: 1; /* Sit on top */
+  width: 100%; /* Full width */
+  height: 100%; /* Full height */
+        "#;
+        let parsed = Parser::parse(test_str).expect("Failed to Parse Style");
+
+        let expected = Sheet::from(vec![ScopeContent::Block(Block {
+            condition: vec![].into(),
+            style_attributes: vec![
+                StyleAttribute {
+                    key: "position".into(),
+                    value: vec!["fixed".into()].into(),
+                },
+                StyleAttribute {
+                    key: "z-index".into(),
+                    value: vec!["1".into()].into(),
+                },
+                StyleAttribute {
+                    key: "width".into(),
+                    value: vec!["100%".into()].into(),
+                },
+                StyleAttribute {
+                    key: "height".into(),
+                    value: vec!["100%".into()].into(),
+                },
+            ]
+            .into(),
+        })]);
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
     fn test_empty_media_rule() {
         init();
         let test_str = r#"@media screen and (max-width: 500px) {}"#;
@@ -1041,6 +1108,7 @@ mod tests {
                     /* a comment with * */
                     display: flex;
                 }
+                /* end comment */
             "#;
         let parsed = Parser::parse(test_str).expect("Failed to Parse Style");
 


### PR DESCRIPTION
While working on #36  I noticed a few things about the parser, that are part of this pr, since addressing them helped me understand the issue.

- The helper parser combinators `expect_non_empty`, preferred over the `|i| { Parser::expect_non_empty(i)?` style, and `traced_context`, unifying `#[test] debug!(...)` have been added.
- `Parser::sp` was always used as `opt(Self::sp)` and has been rewritten to reflect that.
- `Parser::sp` now includes comments, which are hence parsed as if they were whitespace. This was the conclusion of asking on the nom gitter how to best ignore comments in arbitrary positions.
- closes #36 

There is potential for a follow up that looks over all the parsers and tries to rewrite things so that `Self::sp` is not called twice at the same input position, but that is not necessarily a part of this, but let me know if I should do that @futursolo.
