### PR TITLE
Address spacing in combinators

### DIFF
--- a/packages/stylist-macros/src/inline/parse/mod.rs
+++ b/packages/stylist-macros/src/inline/parse/mod.rs
@@ -108,13 +108,10 @@ fn normalize_hierarchy_impl<'it>(
 pub fn fragment_spacing(l: &OutputFragment, r: &OutputFragment) -> Option<OutputFragment> {
     use super::component_value::PreservedToken::*;
     use OutputFragment::*;
-    let needs_spacing = matches!(
-        (l, r),
-        (Delimiter(_, false), Token(Ident(_)))
-            | (
-                Token(Ident(_)) | Token(Literal(_)),
-                Token(Ident(_)) | Token(Literal(_))
-            )
-    );
+    let left_ends_compound = matches!(l, Delimiter(_, false) | Token(Ident(_)) | Token(Literal(_)))
+        || matches!(l, Token(Punct(ref p)) if p.as_char() == '*');
+    let right_starts_compound = matches!(r, Token(Ident(_)) | Token(Literal(_)))
+        || matches!(r, Token(Punct(ref p)) if "*#".contains(p.as_char()));
+    let needs_spacing = left_ends_compound && right_starts_compound;
     needs_spacing.then(|| ' '.into())
 }

--- a/packages/stylist/src/macros.rs
+++ b/packages/stylist/src/macros.rs
@@ -84,6 +84,20 @@
 //! string interpolation as in `${"4em"}`. Similarly, some color hash-tokens like `#44444e` as misinterpreted,
 //! use the same workaround here: `${"#44444e"}`.
 //!
+//! The stable Rust tokenizer also currently offers no way to inspect whitespace between tokens, as tracked in
+//! [the Span inspection API issue](https://github.com/rust-lang/rust/issues/54725). This means that, e.g. the two
+//! selectors `.class-a.class-b` and `.class-a .class-b` can not be differentiated. **The macro errs on side of the
+//! former input without any spaces.** If you meant to write the latter, use `.class-a *.class-b`.
+//!
+//! To be more specific, a space is inserted between two tokens `L R` iff (regardless of the space being present in the macro input):
+//! - `L` is either a closing bracket `)}]`, an identifier `red`, a literal string `"\e600"` or number `3px`, or the '*' character.
+//! - `R` is either an identifier, a literal string or number, the '*' or '#' character.
+//! Spacing around interpolation is ignored regardless.
+//!
+//! Be aware that the above is subject to change once the Span API is stabilized. To avoid future rewriting, use spacing
+//! in your source code that follows the same rules. Refer to the associated [bug report](https://github.com/futursolo/stylist-rs/issues/41)
+//! to discuss this limitation and offer additional suggestions
+//!
 //! ## Note
 //!
 //! This syntax provides more precise error locations and advanced diagnostics information.

--- a/packages/stylist/tests/macro_integrations/complicated-attributes-pass.rs
+++ b/packages/stylist/tests/macro_integrations/complicated-attributes-pass.rs
@@ -56,11 +56,11 @@ box-shadow: 3px 3px red,-1rem 0 0.4rem olive;
 .{cls} article span {{
 box-shadow: inset 0 1px 2px rgba(0.32,0,0,15%);
 }}
-.{cls} a[href*="login"], .{cls} a[href^="https://"], .{cls} a[rel~="tag"], .{cls} a[lang|="en"] {{
+.{cls} a[href *="login"], .{cls} a[href^="https://"], .{cls} a[rel~="tag"], .{cls} a[lang|="en"] {{
 background-image: url("images/pdf.png");
 }}
 .{cls} #content::after {{
-content: " (" attr(x)")";
+content: " (" attr(x) ")";
 }}
 "#,
         cls = style.get_class_name()

--- a/packages/stylist/tests/macro_integrations/whitespace-workaround-pass.rs
+++ b/packages/stylist/tests/macro_integrations/whitespace-workaround-pass.rs
@@ -1,0 +1,39 @@
+fn main() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let style = stylist::style! {
+        &.class-a.class-b {
+            color: red;
+        }
+        // FIXME: this test case is currently documenting a quirk with the inline style.
+        // Once it can be fixed (proc_macro_span, https://github.com/rust-lang/rust/issues/54725)
+        // update this test case output and the documentation
+        //       v-- whitespace not detected
+        &.class-a .class-b {
+            color: black;
+        }
+        &.class-a *.class-b {
+            color: white;
+        }
+        &.class-a #content {
+            color: white;
+        }
+    }
+    .unwrap();
+    let expected_result = format!(
+        r#".{cls}.class-a.class-b {{
+color: red;
+}}
+.{cls}.class-a.class-b {{
+color: black;
+}}
+.{cls}.class-a *.class-b {{
+color: white;
+}}
+.{cls}.class-a #content {{
+color: white;
+}}
+"#,
+        cls = style.get_class_name()
+    );
+    assert_eq!(expected_result, style.get_style_str());
+}


### PR DESCRIPTION
Closes #41 

By inspecting [the CSS Selector Spec](https://www.w3.org/TR/selectors-4/#typedef-selector-list) this identifies tokens that are used at the start or end of `<compound-selector>`, which signals the intended use of a descendant combinator if no other token is present between them. Expand documentation on this issue and add test cases + ref to upstream tracking of the span API in the rust compiler.

Specifically, `*` can either start or end a selector, and `#` can appear at the start. The rest of the tokens like `.class` or `::before` are to be disambiguated by adding a `*` star selector in front of them to force the spacing.