### PR TITLE
Fix whitespace after generated class

### DIFF
--- a/packages/stylist-macros/src/inline/parse/mod.rs
+++ b/packages/stylist-macros/src/inline/parse/mod.rs
@@ -67,7 +67,7 @@ pub fn fragment_spacing(l: &OutputFragment, r: &OutputFragment) -> Option<Output
     use super::component_value::PreservedToken::*;
     use OutputFragment::*;
     let left_ends_compound = matches!(l, Delimiter(_, false) | Token(Ident(_)) | Token(Literal(_)))
-        || matches!(l, Token(Punct(ref p)) if p.as_char() == '*');
+        || matches!(l, Token(Punct(ref p)) if "&*".contains(p.as_char()));
     let right_starts_compound = matches!(r, Token(Ident(_)) | Token(Literal(_)))
         || matches!(r, Token(Punct(ref p)) if "*#".contains(p.as_char()));
     let needs_spacing = left_ends_compound && right_starts_compound;

--- a/packages/stylist/tests/inline_at_supports.rs
+++ b/packages/stylist/tests/inline_at_supports.rs
@@ -1,4 +1,5 @@
-fn main() {
+#[test]
+fn test_inline_at_support() {
     let _ = env_logger::builder().is_test(true).try_init();
     let style = stylist::style! {
         @supports (display: grid) {

--- a/packages/stylist/tests/inline_complicated_attributes.rs
+++ b/packages/stylist/tests/inline_complicated_attributes.rs
@@ -1,4 +1,5 @@
-fn main() {
+#[test]
+fn test_complicated_attributes() {
     let _ = env_logger::builder().is_test(true).try_init();
     let sheet = stylist::ast::sheet! {
         border: medium dashed green;

--- a/packages/stylist/tests/inline_display_impl.rs
+++ b/packages/stylist/tests/inline_display_impl.rs
@@ -13,7 +13,9 @@ impl Foo {
         "confused user impl".into()
     }
 }
-fn main() {
+
+#[test]
+fn test_display_impl() {
     let style = stylist::style! {
         display: ${Foo::Bar};
     }

--- a/packages/stylist/tests/inline_nested_at_rule.rs
+++ b/packages/stylist/tests/inline_nested_at_rule.rs
@@ -1,4 +1,5 @@
-fn main() {
+#[test]
+fn test_nested_at_rule() {
     let _ = env_logger::builder().is_test(true).try_init();
     let dynamic_value = "blue";
     let style = stylist::style! {

--- a/packages/stylist/tests/inline_whitespace_workaround.rs
+++ b/packages/stylist/tests/inline_whitespace_workaround.rs
@@ -1,4 +1,5 @@
-fn main() {
+#[test]
+fn test_whitespace_workaround() {
     let _ = env_logger::builder().is_test(true).try_init();
     let style = stylist::style! {
         &.class-a.class-b {
@@ -17,6 +18,8 @@ fn main() {
         &.class-a #content {
             color: white;
         }
+        & p { line-height: inherit; }
+        & *.leaving { opacity: 0; }
     }
     .unwrap();
     let expected_result = format!(
@@ -31,6 +34,12 @@ fn main() {
 }}
 .{cls}.class-a #content {{
     color: white;
+}}
+.{cls} p {{
+    line-height: inherit;
+}}
+.{cls} *.leaving {{
+    opacity: 0;
 }}
 "#,
         cls = style.get_class_name()

--- a/packages/stylist/tests/literal_at_supports.rs
+++ b/packages/stylist/tests/literal_at_supports.rs
@@ -1,4 +1,5 @@
-fn main() {
+#[test]
+fn test_literal_at_support() {
     let style = stylist::style! {
         r#"@supports (display:grid) {
             background-color: grey;


### PR DESCRIPTION
This fixes a problem with inline syntax where `& p { ... }` would not insert a space resulting in confusing output.

After replacing `&` with the generated class name, the above should be equivalent to `.stylist-hash p { }`, which would insert a space correctly (between two identifiers). This fixes this discrepancy.

Also fixes an oversight where some tests where not executed due to missing the `#[test]` attribute.