### PR TITLE
Upgrade examples to upstream yew

### DIFF
--- a/examples/use-media-query/Cargo.toml
+++ b/examples/use-media-query/Cargo.toml
@@ -8,9 +8,13 @@ edition = "2018"
 log = "0.4.14"
 console_log = { version = "0.2.0", features = ["color"] }
 yew = { git = "https://github.com/yewstack/yew" }
-stylist = { path = "../../packages/stylist", features = ["yew_integration", "yew_use_media_query"] }
+stylist = { path = "../../packages/stylist", features = [
+    "yew_integration",
+    "yew_use_media_query",
+] }
 
 [dev-dependencies]
+gloo-utils = "0.1"
 wasm-bindgen-test = "0.3.27"
 wasm-bindgen = "0.2.77"
 

--- a/examples/use-media-query/src/main.rs
+++ b/examples/use-media-query/src/main.rs
@@ -69,7 +69,7 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_simple() {
         yew::start_app_in_element::<App>(
-            yew::utils::document().get_element_by_id("output").unwrap(),
+            gloo_utils::document().get_element_by_id("output").unwrap(),
         );
         let window = window().unwrap();
         let doc = window.document().unwrap();

--- a/examples/yew-integration/Cargo.toml
+++ b/examples/yew-integration/Cargo.toml
@@ -11,6 +11,7 @@ yew = { git = "https://github.com/yewstack/yew" }
 stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
 
 [dev-dependencies]
+gloo-utils = "0.1"
 wasm-bindgen-test = "0.3.27"
 wasm-bindgen = "0.2.77"
 

--- a/examples/yew-integration/src/main.rs
+++ b/examples/yew-integration/src/main.rs
@@ -86,7 +86,7 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_simple() {
         yew::start_app_in_element::<App>(
-            yew::utils::document().get_element_by_id("output").unwrap(),
+            gloo_utils::document().get_element_by_id("output").unwrap(),
         );
         let window = window().unwrap();
         let doc = window.document().unwrap();

--- a/examples/yew-proc-macros/Cargo.toml
+++ b/examples/yew-proc-macros/Cargo.toml
@@ -8,9 +8,13 @@ edition = "2018"
 log = "0.4.14"
 console_log = { version = "0.2.0", features = ["color"] }
 yew = { git = "https://github.com/yewstack/yew" }
-stylist = { path = "../../packages/stylist", default-features = false, features = ["yew_integration", "macros"] }
+stylist = { path = "../../packages/stylist", default-features = false, features = [
+    "yew_integration",
+    "macros",
+] }
 
 [dev-dependencies]
+gloo-utils = "0.1"
 wasm-bindgen-test = "0.3.27"
 wasm-bindgen = "0.2.77"
 

--- a/examples/yew-proc-macros/src/main.rs
+++ b/examples/yew-proc-macros/src/main.rs
@@ -86,7 +86,7 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_simple() {
         yew::start_app_in_element::<App>(
-            yew::utils::document().get_element_by_id("output").unwrap(),
+            gloo_utils::document().get_element_by_id("output").unwrap(),
         );
         let window = window().unwrap();
         let doc = window.document().unwrap();

--- a/examples/yew-theme-context/Cargo.toml
+++ b/examples/yew-theme-context/Cargo.toml
@@ -13,6 +13,7 @@ stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
 once_cell = "1.8.0"
 
 [dev-dependencies]
+gloo-utils = "0.1"
 wasm-bindgen-test = "0.3.27"
 wasm-bindgen = "0.2.77"
 

--- a/examples/yew-theme-context/src/main.rs
+++ b/examples/yew-theme-context/src/main.rs
@@ -124,7 +124,7 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_simple() {
         yew::start_app_in_element::<App>(
-            yew::utils::document().get_element_by_id("output").unwrap(),
+            gloo_utils::document().get_element_by_id("output").unwrap(),
         );
         let window = window().unwrap();
         let doc = window.document().unwrap();

--- a/examples/yew-theme-hooks/Cargo.toml
+++ b/examples/yew-theme-hooks/Cargo.toml
@@ -9,10 +9,14 @@ log = "0.4.14"
 console_log = { version = "0.2.0", features = ["color"] }
 yew = { git = "https://github.com/yewstack/yew" }
 yewtil = "0.4.0"
-stylist = { path = "../../packages/stylist", features = ["yew_integration", "yew_use_style"] }
+stylist = { path = "../../packages/stylist", features = [
+    "yew_integration",
+    "yew_use_style",
+] }
 once_cell = "1.8.0"
 
 [dev-dependencies]
+gloo-utils = "0.1"
 wasm-bindgen-test = "0.3.27"
 wasm-bindgen = "0.2.77"
 

--- a/examples/yew-theme-hooks/src/main.rs
+++ b/examples/yew-theme-hooks/src/main.rs
@@ -132,7 +132,7 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_simple() {
         yew::start_app_in_element::<App>(
-            yew::utils::document().get_element_by_id("output").unwrap(),
+            gloo_utils::document().get_element_by_id("output").unwrap(),
         );
         let window = window().unwrap();
         let doc = window.document().unwrap();

--- a/packages/stylist/src/style.rs
+++ b/packages/stylist/src/style.rs
@@ -34,6 +34,7 @@ impl fmt::Display for StyleId {
 
 #[derive(Debug)]
 pub(crate) struct StyleContent {
+    #[allow(dead_code)]
     pub is_global: bool,
 
     pub id: StyleId,


### PR DESCRIPTION
In the course of changing stuff for #55 I discovered that the examples expect yew to re-export some stuff from `gloo_utils`, which must now be imported directly. In preparation for the release of yew, this fix.