### PR TITLE
Yew centered default features

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,20 @@ Add the following to your `Cargo.toml`:
 stylist = "0.10"
 ```
 
+By default, the `yew_integration` feature is enabled. If you want to use stylist outside of `yew`,
+use a variation of
+
+```toml
+stylist = { version = "0.10", default-features = false }
+```
+
 ## Usage
 
-For detailed usage, please see
-[documentation](https://docs.rs/stylist/).
+For detailed usage, please see [documentation](https://docs.rs/stylist/).
 
 ### Yew Integration
 
-To style your component, you can use `styled_component` attribute with `css!`
+To style your component, you can use the `styled_component` attribute which injects a `css!`
 macro.
 
 ```rust
@@ -61,7 +67,8 @@ println!("{}", style.get_class_name());
 
 ### Runtime Style
 
-If you want to parse a string into a style at runtime, you can use `Style::new`:
+If you want to parse a string into a style at runtime, you can use `Style::new`.
+You must also enable the optional `parser` feature.
 
 ```rust
 use stylist::Style;

--- a/examples/benchmarks/Cargo.toml
+++ b/examples/benchmarks/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 log = "0.4.14"
 console_log = { version = "0.2.0", features = ["color"] }
 yew = { version = "0.19" }
-stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
+stylist = { path = "../../packages/stylist", features = ["parser"] }
 web-sys = { version = "0.3.54", features = ["Window", "Performance"] }
 gloo = "0.4.0"

--- a/examples/use-media-query/Cargo.toml
+++ b/examples/use-media-query/Cargo.toml
@@ -8,10 +8,7 @@ edition = "2018"
 log = "0.4.14"
 console_log = { version = "0.2.0", features = ["color"] }
 yew = { version = "0.19" }
-stylist = { path = "../../packages/stylist", features = [
-    "yew_integration",
-    "yew_use_media_query",
-] }
+stylist = { path = "../../packages/stylist" }
 
 [dev-dependencies]
 gloo-utils = "0.1"

--- a/examples/yew-integration/Cargo.toml
+++ b/examples/yew-integration/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 log = "0.4.14"
 console_log = { version = "0.2.0", features = ["color"] }
 yew = { version = "0.19" }
-stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
+stylist = { path = "../../packages/stylist" }
 
 [dev-dependencies]
 gloo-utils = "0.1"

--- a/examples/yew-integration/src/main.rs
+++ b/examples/yew-integration/src/main.rs
@@ -29,7 +29,7 @@ pub fn app() -> Html {
     html! {
         <>
             // Global Styles can be applied with <Global /> component.
-            <Global css=r#"
+            <Global css={css!(r#"
                     html, body {
                         font-family: sans-serif;
 
@@ -44,7 +44,7 @@ pub fn app() -> Html {
 
                         background-color: rgb(237, 244, 255);
                     }
-                "# />
+                "#)} />
             <h1>{"Yew Integration"}</h1>
             <div class={css!(r#"
                 box-shadow: 0 0 5px 1px rgba(0, 0, 0, 0.7);

--- a/examples/yew-proc-macros/Cargo.toml
+++ b/examples/yew-proc-macros/Cargo.toml
@@ -8,10 +8,7 @@ edition = "2018"
 log = "0.4.14"
 console_log = { version = "0.2.0", features = ["color"] }
 yew = { version = "0.19" }
-stylist = { path = "../../packages/stylist", default-features = false, features = [
-    "yew_integration",
-    "macros",
-] }
+stylist = { path = "../../packages/stylist" }
 
 [dev-dependencies]
 gloo-utils = "0.1"

--- a/examples/yew-shadow/Cargo.toml
+++ b/examples/yew-shadow/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 log = "0.4.14"
 console_log = { version = "0.2.0", features = ["color"] }
 yew = { version = "0.19" }
-stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
+stylist = { path = "../../packages/stylist" }
 once_cell = "1.8.0"
 
 [dependencies.web-sys]

--- a/examples/yew-theme-context/Cargo.toml
+++ b/examples/yew-theme-context/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 log = "0.4.14"
 console_log = { version = "0.2.0", features = ["color"] }
 yew = { version = "0.19" }
-stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
+stylist = { path = "../../packages/stylist" }
 once_cell = "1.8.0"
 
 [dev-dependencies]

--- a/examples/yew-theme-hooks/Cargo.toml
+++ b/examples/yew-theme-hooks/Cargo.toml
@@ -8,10 +8,7 @@ edition = "2018"
 log = "0.4.14"
 console_log = { version = "0.2.0", features = ["color"] }
 yew = { version = "0.19" }
-stylist = { path = "../../packages/stylist", features = [
-    "yew_integration",
-    "yew_use_style",
-] }
+stylist = { path = "../../packages/stylist" }
 once_cell = "1.8.0"
 
 [dev-dependencies]

--- a/packages/stylist/Cargo.toml
+++ b/packages/stylist/Cargo.toml
@@ -48,16 +48,12 @@ trybuild = "1.0.53"
 yew = "0.19.3"
 
 [features]
+default = ["macros", "yew_integration", "random"]
 random = ["fastrand", "instant"]
 macros = ["stylist-macros"]
 parser = ["stylist-core/parser"]
-default = ["macros", "parser", "random"]
 yew_integration = ["yew", "yew_use_media_query", "yew_use_style"]
-yew_use_media_query = [
-    "yew",
-    "web-sys/MediaQueryList",
-    "gloo-events",
-]
+yew_use_media_query = ["yew", "web-sys/MediaQueryList", "gloo-events"]
 yew_use_style = ["yew"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
It seems that most of the users are running yew, which (as also mentioned on discord once) requires one to activate the optional `yew_integration` feature. This point of this PR is to commit to making this the default and demote the `parser` feature to be used for `stylist-macros`, but not by default by `stylist` itself. Unless you explicitly want to parse user-provided css, there is no good reason I can come up with to not use the macros instead to convert literal css to styles.