### PR TITLE
Add source locations, powered by #[track_caller]

### DIFF
--- a/packages/stylist/Cargo.toml
+++ b/packages/stylist/Cargo.toml
@@ -51,13 +51,10 @@ yew = "0.19.3"
 random = ["fastrand", "instant"]
 macros = ["stylist-macros"]
 parser = ["stylist-core/parser"]
-default = ["macros", "parser", "random"]
+default = ["macros", "parser", "random", "debug_style_locations"]
+debug_style_locations = []
 yew_integration = ["yew", "yew_use_media_query", "yew_use_style"]
-yew_use_media_query = [
-    "yew",
-    "web-sys/MediaQueryList",
-    "gloo-events",
-]
+yew_use_media_query = ["yew", "web-sys/MediaQueryList", "gloo-events"]
 yew_use_style = ["yew"]
 
 [package.metadata.docs.rs]

--- a/packages/stylist/src/global_style.rs
+++ b/packages/stylist/src/global_style.rs
@@ -6,8 +6,7 @@ use stylist_core::ResultDisplay;
 use crate::ast::ToStyleStr;
 use crate::manager::StyleManager;
 use crate::registry::StyleKey;
-use crate::style::StyleContent;
-use crate::style::StyleId;
+use crate::style::{StyleContent, StyleId};
 use crate::utils::get_entropy;
 use crate::{Result, StyleSource};
 
@@ -30,7 +29,7 @@ impl GlobalStyle {
         use crate::ast::Sheet;
 
         let prefix = format!("{}-global", manager.prefix());
-        let css = css.try_to_sheet()?;
+        let css = css.try_into_sheet()?;
 
         // Creates the StyleKey, return from registry if already cached.
         let key = StyleKey {

--- a/packages/stylist/src/style.rs
+++ b/packages/stylist/src/style.rs
@@ -159,7 +159,7 @@ impl Style {
         #[cfg(all(debug_assertions, feature = "parser"))]
         use crate::ast::Sheet;
 
-        let css = css.try_to_sheet()?;
+        let css = css.try_into_sheet()?;
 
         // Creates the StyleKey, return from registry if already cached.
         let key = StyleKey {

--- a/packages/stylist/src/yew/mod.rs
+++ b/packages/stylist/src/yew/mod.rs
@@ -1,7 +1,6 @@
 //! This module contains yew specific features.
 
-use yew::html::Classes;
-use yew::html::IntoPropValue;
+use yew::html::{Classes, IntoPropValue};
 
 /// A procedural macro to style a function component.
 ///
@@ -110,7 +109,12 @@ impl From<Style> for Classes {
 impl From<StyleSource<'_>> for Classes {
     fn from(style_src: StyleSource<'_>) -> Self {
         let mut classes = Self::new();
-        classes.push(style_src.to_style().get_class_name().to_string());
+        #[cfg(all(debug_assertions, feature = "debug_style_locations"))]
+        let location = style_src.location.clone();
+        let style = style_src.into_style();
+        classes.push(style.get_class_name().to_string());
+        #[cfg(all(debug_assertions, feature = "debug_style_locations"))]
+        classes.push(location);
         classes
     }
 }


### PR DESCRIPTION
Adds a (non-functional) additional class to the element when compiled with `debug_assertions`, i.e. in development mode.

Uses the [`#[track_caller]`](https://doc.rust-lang.org/stable/std/panic/struct.Location.html#method.caller) API to determined where a style was created and then "formats" that as a css class name. Addresses the underlying issue of #61 , adding debug possiblities to determine where a style is coming from.