### PR TITLE
Update to yew 0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Feature `parser`: The conversion from `str` have been changed to `TryFrom`
   instead of `From`. If you're using `yew`, the `IntoPropValue<StyleSource>`
   impls still exist, but now panic early during conversion.
+- Feature `parser`: This feature is now disabled by default. Use the `css!`, other
+  macros and interpolation syntax to write styles, if you don't need to parse css at
+  runtime.
 
 ### Other Changes:
 - The `Style::new_*` API is more open for accepted types of the `Css` parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Other Changes:
 - The `Style::new_*` API is more open for accepted types of the `Css` parameter.
+- The name of styled components now defaults to the name of the function, like in
+  `function_component`.
 
 ## v0.10.1
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ macro.
 use yew::prelude::*;
 use stylist::yew::styled_component;
 
-#[styled_component(MyStyledComponent)]
-fn my_styled_component() -> Html {
+#[styled_component]
+fn MyStyledComponent() -> Html {
     html! {<div class={css!("color: red;")}>{"Hello World!"}</div>}
 }
 ```

--- a/examples/benchmarks/Cargo.toml
+++ b/examples/benchmarks/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
 yew = { version = "0.20", features = ["csr"] }
-stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
+stylist = { path = "../../packages/stylist", features = [
+    "yew_integration",
+    "parser",
+] }
 web-sys = { version = "0.3.58", features = ["Window", "Performance"] }
 gloo = "0.8.0"

--- a/examples/benchmarks/Cargo.toml
+++ b/examples/benchmarks/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-yew = "0.19.3"
+yew = { version = "0.20", features = ["csr"] }
 stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
 web-sys = { version = "0.3.58", features = ["Window", "Performance"] }
 gloo = "0.8.0"

--- a/examples/benchmarks/src/main.rs
+++ b/examples/benchmarks/src/main.rs
@@ -371,5 +371,5 @@ impl Component for App {
 
 fn main() {
     console_log::init_with_level(Level::Trace).expect("Failed to initialise Log!");
-    yew::start_app::<App>();
+    yew::Renderer::<App>::new().render();
 }

--- a/examples/use-media-query/Cargo.toml
+++ b/examples/use-media-query/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-yew = "0.19.3"
+yew = { version = "0.20", features = ["csr"] }
 stylist = { path = "../../packages/stylist", features = [
     "yew_integration",
     "yew_use_media_query",

--- a/examples/use-media-query/src/main.rs
+++ b/examples/use-media-query/src/main.rs
@@ -54,7 +54,7 @@ pub fn app() -> Html {
 
 fn main() {
     console_log::init_with_level(Level::Trace).expect("Failed to initialise Log!");
-    yew::start_app::<App>();
+    yew::Renderer::<App>::new().render();
 }
 
 #[cfg(test)]
@@ -68,9 +68,10 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_simple() {
-        yew::start_app_in_element::<App>(
+        yew::Renderer::<App>::with_root(
             gloo_utils::document().get_element_by_id("output").unwrap(),
-        );
+        )
+        .render();
         let window = window().unwrap();
         let doc = window.document().unwrap();
         let body = window.document().unwrap().body().unwrap();

--- a/examples/use-media-query/src/main.rs
+++ b/examples/use-media-query/src/main.rs
@@ -3,8 +3,8 @@ use yew::prelude::*;
 
 use log::Level;
 
-#[styled_component(App)]
-pub fn app() -> Html {
+#[styled_component]
+pub fn App() -> Html {
     let is_small = use_media_query("(max-width: 720px)");
 
     let size_name = if is_small { "small" } else { "big" };

--- a/examples/use-media-query/src/main.rs
+++ b/examples/use-media-query/src/main.rs
@@ -11,7 +11,7 @@ pub fn app() -> Html {
 
     html! {
         <>
-            <Global css=r#"
+            <Global css={css!(r#"
                     html, body {
                         font-family: sans-serif;
 
@@ -26,7 +26,7 @@ pub fn app() -> Html {
 
                         background-color: rgb(237, 244, 255);
                     }
-                "# />
+                "#)} />
             <h1>{"Use Media Query Example"}</h1>
             <div class={css!(r#"
                 box-shadow: 0 0 5px 1px rgba(0, 0, 0, 0.7);

--- a/examples/yew-integration/Cargo.toml
+++ b/examples/yew-integration/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-yew = "0.19.3"
+yew = { version = "0.20", features = ["csr"] }
 stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
 
 [dev-dependencies]

--- a/examples/yew-integration/Cargo.toml
+++ b/examples/yew-integration/Cargo.toml
@@ -12,6 +12,7 @@ stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
 
 [dev-dependencies]
 gloo-utils = "0.1.4"
+gloo-timers = { version = "0.2.4", features = ["futures"] }
 wasm-bindgen-test = "0.3.31"
 wasm-bindgen = "0.2.81"
 

--- a/examples/yew-integration/src/main.rs
+++ b/examples/yew-integration/src/main.rs
@@ -3,8 +3,8 @@ use yew::prelude::*;
 
 use log::Level;
 
-#[styled_component(Inside)]
-pub fn inside() -> Html {
+#[styled_component]
+pub fn Inside() -> Html {
     html! {
         <div class={css!(r#"
             width: 200px;
@@ -24,8 +24,8 @@ pub fn inside() -> Html {
     }
 }
 
-#[styled_component(App)]
-pub fn app() -> Html {
+#[styled_component]
+pub fn App() -> Html {
     html! {
         <>
             // Global Styles can be applied with <Global /> component.

--- a/examples/yew-integration/src/main.rs
+++ b/examples/yew-integration/src/main.rs
@@ -84,11 +84,14 @@ mod tests {
     use web_sys::window;
 
     #[wasm_bindgen_test]
-    fn test_simple() {
+    async fn test_simple() {
         yew::Renderer::<App>::with_root(
             gloo_utils::document().get_element_by_id("output").unwrap(),
         )
         .render();
+        // wait for lifecycles to process
+        gloo_timers::future::TimeoutFuture::new(0).await;
+
         let window = window().unwrap();
         let doc = window.document().unwrap();
         let body = window.document().unwrap().body().unwrap();

--- a/examples/yew-integration/src/main.rs
+++ b/examples/yew-integration/src/main.rs
@@ -71,7 +71,7 @@ pub fn app() -> Html {
 
 fn main() {
     console_log::init_with_level(Level::Trace).expect("Failed to initialise Log!");
-    yew::start_app::<App>();
+    yew::Renderer::<App>::new().render();
 }
 
 #[cfg(test)]
@@ -85,9 +85,10 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_simple() {
-        yew::start_app_in_element::<App>(
+        yew::Renderer::<App>::with_root(
             gloo_utils::document().get_element_by_id("output").unwrap(),
-        );
+        )
+        .render();
         let window = window().unwrap();
         let doc = window.document().unwrap();
         let body = window.document().unwrap().body().unwrap();

--- a/examples/yew-integration/src/main.rs
+++ b/examples/yew-integration/src/main.rs
@@ -29,7 +29,7 @@ pub fn app() -> Html {
     html! {
         <>
             // Global Styles can be applied with <Global /> component.
-            <Global css=r#"
+            <Global css={css!(r#"
                     html, body {
                         font-family: sans-serif;
 
@@ -44,7 +44,7 @@ pub fn app() -> Html {
 
                         background-color: rgb(237, 244, 255);
                     }
-                "# />
+                "#)} />
             <h1>{"Yew Integration"}</h1>
             <div class={css!(r#"
                 box-shadow: 0 0 5px 1px rgba(0, 0, 0, 0.7);

--- a/examples/yew-proc-macros/Cargo.toml
+++ b/examples/yew-proc-macros/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-yew = "0.19.3"
+yew = { version = "0.20", features = ["csr"] }
 stylist = { path = "../../packages/stylist", default-features = false, features = [
     "yew_integration",
     "macros",

--- a/examples/yew-proc-macros/src/main.rs
+++ b/examples/yew-proc-macros/src/main.rs
@@ -3,8 +3,8 @@ use yew::prelude::*;
 
 use log::Level;
 
-#[styled_component(Inside)]
-pub fn inside() -> Html {
+#[styled_component]
+pub fn Inside() -> Html {
     html! {
         <div class={css!(r#"
             width: 200px;
@@ -24,8 +24,8 @@ pub fn inside() -> Html {
     }
 }
 
-#[styled_component(App)]
-pub fn app() -> Html {
+#[styled_component]
+pub fn App() -> Html {
     html! {
         <>
             // Global Styles can be applied with <Global /> component.

--- a/examples/yew-proc-macros/src/main.rs
+++ b/examples/yew-proc-macros/src/main.rs
@@ -71,7 +71,7 @@ pub fn app() -> Html {
 
 fn main() {
     console_log::init_with_level(Level::Trace).expect("Failed to initialise Log!");
-    yew::start_app::<App>();
+    yew::Renderer::<App>::new().render();
 }
 
 #[cfg(test)]
@@ -85,9 +85,10 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_simple() {
-        yew::start_app_in_element::<App>(
+        yew::Renderer::<App>::with_root(
             gloo_utils::document().get_element_by_id("output").unwrap(),
-        );
+        )
+        .render();
         let window = window().unwrap();
         let doc = window.document().unwrap();
         let body = window.document().unwrap().body().unwrap();

--- a/examples/yew-shadow/Cargo.toml
+++ b/examples/yew-shadow/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-yew = "0.19.3"
+yew = { version = "0.20", features = ["csr"] }
 stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
 once_cell = "1.13.0"
 

--- a/examples/yew-shadow/src/main.rs
+++ b/examples/yew-shadow/src/main.rs
@@ -136,5 +136,5 @@ impl Component for App {
 
 fn main() {
     console_log::init_with_level(Level::Trace).expect("Failed to initialise Log!");
-    yew::start_app::<App>();
+    yew::Renderer::<App>::new().render();
 }

--- a/examples/yew-shadow/src/main.rs
+++ b/examples/yew-shadow/src/main.rs
@@ -1,6 +1,6 @@
 use stylist::manager::StyleManager;
 use stylist::yew::Global;
-use stylist::Style;
+use stylist::{css, Style};
 use web_sys::{window, Element, ShadowRootInit, ShadowRootMode};
 use yew::prelude::*;
 
@@ -30,7 +30,8 @@ impl Component for ShadowRoot {
                         .expect("Failed to create manager.");
 
                     let style = Style::new_with_manager(
-                        r#"
+                        css!(
+                            r#"
                             background-color: pink;
                             width: 200px;
                             height: 200px;
@@ -41,7 +42,8 @@ impl Component for ShadowRoot {
                             box-sizing: border-box;
 
                             box-shadow: 0 0 5px 1px rgba(0, 0, 0, 0.7);
-                        "#,
+                        "#
+                        ),
                         mgr,
                     )
                     .unwrap();
@@ -104,7 +106,7 @@ impl Component for App {
         );
         html! {
             <>
-                <Global css=r#"
+                <Global css={css!(r#"
                     html, body {
                         font-family: sans-serif;
 
@@ -123,7 +125,7 @@ impl Component for App {
                     span {
                         color: red;
                     }
-                "# />
+                "#)} />
                 <h1>{"Yew Shadow DOM Example"}</h1>
                 <div class={card}>
                     <span>{"Outside of Shadow DOM."}</span>

--- a/examples/yew-theme-context/Cargo.toml
+++ b/examples/yew-theme-context/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-yew = "0.19.3"
+yew = { version = "0.20", features = ["csr"] }
 stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
 once_cell = "1.13.0"
 

--- a/examples/yew-theme-context/src/contexts/theme.rs
+++ b/examples/yew-theme-context/src/contexts/theme.rs
@@ -93,6 +93,7 @@ pub(crate) fn theme_provider(props: &ThemeProviderProps) -> Html {
     }
 }
 
+#[hook]
 pub(crate) fn use_theme() -> ThemeContext {
     use_context::<ThemeContext>().unwrap()
 }

--- a/examples/yew-theme-context/src/contexts/theme.rs
+++ b/examples/yew-theme-context/src/contexts/theme.rs
@@ -65,7 +65,7 @@ impl Deref for ThemeContext {
     type Target = Theme;
 
     fn deref(&self) -> &Self::Target {
-        &*self.inner.current()
+        self.inner.current()
     }
 }
 
@@ -80,8 +80,8 @@ pub(crate) struct ThemeProviderProps {
     pub children: Children,
 }
 
-#[styled_component(ThemeProvider)]
-pub(crate) fn theme_provider(props: &ThemeProviderProps) -> Html {
+#[styled_component]
+pub(crate) fn ThemeProvider(props: &ThemeProviderProps) -> Html {
     let theme_kind = use_state(|| ThemeKind::Light);
 
     let theme_ctx = ThemeContext::new(theme_kind);

--- a/examples/yew-theme-context/src/main.rs
+++ b/examples/yew-theme-context/src/main.rs
@@ -108,7 +108,7 @@ pub fn root() -> Html {
 
 fn main() {
     console_log::init_with_level(Level::Trace).expect("Failed to initialise Log!");
-    yew::start_app::<Root>();
+    yew::Renderer::<Root>::new().render();
 }
 
 #[cfg(test)]
@@ -123,9 +123,10 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_simple() {
-        yew::start_app_in_element::<App>(
+        yew::Renderer::<App>::with_root(
             gloo_utils::document().get_element_by_id("output").unwrap(),
-        );
+        )
+        .render();
         let window = window().unwrap();
         let doc = window.document().unwrap();
         let body = window.document().unwrap().body().unwrap();

--- a/examples/yew-theme-context/src/main.rs
+++ b/examples/yew-theme-context/src/main.rs
@@ -7,8 +7,8 @@ mod contexts;
 
 use contexts::{use_theme, ThemeKind, ThemeProvider};
 
-#[styled_component(Inside)]
-pub fn inside() -> Html {
+#[styled_component]
+pub fn Inside() -> Html {
     let theme = use_theme();
 
     let theme_str = match theme.kind() {
@@ -37,8 +37,8 @@ pub fn inside() -> Html {
     }
 }
 
-#[styled_component(App)]
-pub fn app() -> Html {
+#[styled_component]
+pub fn App() -> Html {
     let theme = use_theme();
 
     let theme_str = match theme.kind() {
@@ -97,8 +97,8 @@ pub fn app() -> Html {
     }
 }
 
-#[styled_component(Root)]
-pub fn root() -> Html {
+#[styled_component]
+pub fn Root() -> Html {
     html! {
         <ThemeProvider>
             <App />

--- a/examples/yew-theme-hooks/Cargo.toml
+++ b/examples/yew-theme-hooks/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-yew = "0.19.3"
+yew = { version = "0.20", features = ["csr"] }
 stylist = { path = "../../packages/stylist", features = [
     "yew_integration",
     "yew_use_style",

--- a/examples/yew-theme-hooks/src/contexts/theme.rs
+++ b/examples/yew-theme-hooks/src/contexts/theme.rs
@@ -93,6 +93,7 @@ pub(crate) fn theme_provider(props: &ThemeProviderProps) -> Html {
     }
 }
 
+#[hook]
 pub(crate) fn use_theme() -> ThemeContext {
     use_context::<ThemeContext>().unwrap()
 }

--- a/examples/yew-theme-hooks/src/contexts/theme.rs
+++ b/examples/yew-theme-hooks/src/contexts/theme.rs
@@ -65,7 +65,7 @@ impl Deref for ThemeContext {
     type Target = Theme;
 
     fn deref(&self) -> &Self::Target {
-        &*self.inner.current()
+        self.inner.current()
     }
 }
 
@@ -80,8 +80,8 @@ pub(crate) struct ThemeProviderProps {
     pub children: Children,
 }
 
-#[styled_component(ThemeProvider)]
-pub(crate) fn theme_provider(props: &ThemeProviderProps) -> Html {
+#[styled_component]
+pub(crate) fn ThemeProvider(props: &ThemeProviderProps) -> Html {
     let theme_kind = use_state(|| ThemeKind::Light);
 
     let theme_ctx = ThemeContext::new(theme_kind);

--- a/examples/yew-theme-hooks/src/main.rs
+++ b/examples/yew-theme-hooks/src/main.rs
@@ -116,7 +116,7 @@ pub fn root() -> Html {
 
 fn main() {
     console_log::init_with_level(Level::Trace).expect("Failed to initialise Log!");
-    yew::start_app::<Root>();
+    yew::Renderer::<Root>::new().render();
 }
 
 #[cfg(test)]
@@ -131,9 +131,10 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_simple() {
-        yew::start_app_in_element::<App>(
+        yew::Renderer::<App>::with_root(
             gloo_utils::document().get_element_by_id("output").unwrap(),
-        );
+        )
+        .render();
         let window = window().unwrap();
         let doc = window.document().unwrap();
         let body = window.document().unwrap().body().unwrap();

--- a/packages/stylist-macros/src/spacing_iterator.rs
+++ b/packages/stylist-macros/src/spacing_iterator.rs
@@ -3,7 +3,7 @@
 #[test]
 fn test_spacing_iterator() {
     use SpacedIterator;
-    let it = (1..7).spaced_with(|l, _| (*l == 4).then(|| 2000));
+    let it = (1..7).spaced_with(|l, _| (*l == 4).then_some(2000));
     itertools::assert_equal(it, vec![1, 2, 3, 4, 2000, 5, 6]);
 }
 

--- a/packages/stylist-macros/src/styled_component.rs
+++ b/packages/stylist-macros/src/styled_component.rs
@@ -7,19 +7,20 @@ use syn::{parse_macro_input, Item, ItemFn};
 use super::styled_component_impl::{styled_component_impl_impl, HookLike};
 
 #[derive(Debug)]
-pub struct StyledComponentName {
-    component_name: Ident,
+pub enum StyledComponentArgs {
+    Named { component_name: Ident },
+    Empty,
 }
 
-impl Parse for StyledComponentName {
+impl Parse for StyledComponentArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         if input.is_empty() {
-            return Err(input.error("expected identifier for the component"));
+            return Ok(Self::Empty);
         }
 
         let component_name = input.parse()?;
 
-        Ok(Self { component_name })
+        Ok(Self::Named { component_name })
     }
 }
 
@@ -41,16 +42,19 @@ impl Parse for StyledComponent {
 }
 
 pub fn styled_component_impl(
-    name: StyledComponentName,
+    args: StyledComponentArgs,
     component: StyledComponent,
 ) -> syn::Result<TokenStream> {
-    let StyledComponentName { component_name } = name;
+    let function_component_args = match args {
+        StyledComponentArgs::Empty => quote! {},
+        StyledComponentArgs::Named { component_name } => quote! { #component_name },
+    };
     let StyledComponent { func } = component;
 
     let inner_tokens = styled_component_impl_impl(HookLike { func })?;
 
     Ok(quote! {
-        #[::yew::functional::function_component(#component_name)]
+        #[::yew::functional::function_component( #function_component_args )]
         #inner_tokens
     })
 }
@@ -60,7 +64,7 @@ pub fn macro_fn(
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let item = parse_macro_input!(item as StyledComponent);
-    let attr = parse_macro_input!(attr as StyledComponentName);
+    let attr = parse_macro_input!(attr as StyledComponentArgs);
 
     styled_component_impl(attr, item)
         .unwrap_or_else(|err| err.to_compile_error())

--- a/packages/stylist/Cargo.toml
+++ b/packages/stylist/Cargo.toml
@@ -48,13 +48,14 @@ trybuild = "1.0.63"
 yew = "0.20"
 
 [features]
-random = ["fastrand", "instant"]
-macros = ["stylist-macros"]
-parser = ["stylist-core/parser"]
-default = ["macros", "parser", "random", "debug_style_locations"]
+default = ["debug_style_locations", "debug_parser", "macros", "random"]
+debug_parser = ["stylist-core/parser"]
 debug_style_locations = []
+macros = ["stylist-macros"]
+random = ["dep:fastrand", "dep:instant"]
+parser = ["stylist-core/parser"]
 yew_integration = ["yew", "yew_use_media_query", "yew_use_style"]
-yew_use_media_query = ["yew", "web-sys/MediaQueryList", "gloo-events"]
+yew_use_media_query = ["yew", "web-sys/MediaQueryList", "dep:gloo-events"]
 yew_use_style = ["yew"]
 
 [package.metadata.docs.rs]

--- a/packages/stylist/Cargo.toml
+++ b/packages/stylist/Cargo.toml
@@ -24,7 +24,7 @@ stylist-macros = { path = "../stylist-macros", version = "0.11", optional = true
 
 once_cell = "1.13.0"
 wasm-bindgen = "0.2.81"
-yew = { version = "0.19.3", optional = true, default-features = false }
+yew = { version = "0.20", optional = true, default-features = false }
 # js-sys = { version = "0.3.55", optional = true }
 gloo-events = { version = "0.1.2", optional = true }
 fastrand = { version = "1.7.0", optional = true }
@@ -45,7 +45,7 @@ features = [
 log = "0.4.17"
 env_logger = "0.9.0"
 trybuild = "1.0.63"
-yew = "0.19.3"
+yew = "0.20"
 
 [features]
 random = ["fastrand", "instant"]

--- a/packages/stylist/src/global_style.rs
+++ b/packages/stylist/src/global_style.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-#[cfg(all(debug_assertions, feature = "parser"))]
+#[cfg(all(debug_assertions, feature = "debug_parser"))]
 use stylist_core::ResultDisplay;
 
 use crate::ast::ToStyleStr;
@@ -46,7 +46,7 @@ impl GlobalStyle {
 
         // We parse the style str again in debug mode to ensure that interpolated values are
         // not corrupting the stylesheet.
-        #[cfg(all(debug_assertions, feature = "parser"))]
+        #[cfg(all(debug_assertions, feature = "debug_parser"))]
         style_str
             .parse::<crate::ast::Sheet>()
             .expect_display("debug: Stylist failed to parse the style with interpolated values");
@@ -143,6 +143,7 @@ impl GlobalStyle {
 }
 
 #[cfg(test)]
+#[cfg(feature = "parser")]
 mod tests {
     use super::*;
 

--- a/packages/stylist/src/lib.rs
+++ b/packages/stylist/src/lib.rs
@@ -101,6 +101,10 @@
 //! - `yew_integration`: This flag enables yew integration, which implements
 //!   [`Classes`](::yew::html::Classes) for [`Style`] and provides a [`Global`](yew::Global)
 //!   component for applying global styles.
+//! - `debug_style_locations`: Enabled by default, this flag annotates elements with additional
+//!   classes to help debugging and finding the source location of styles.
+//! - `debug_parser`: Enabled by default, this flag generates additional checks when
+//!   `debug_assertions` are enabled.
 
 #[cfg(any(feature = "yew_use_media_query", target_arch = "wasm32"))]
 mod arch;

--- a/packages/stylist/src/lib.rs
+++ b/packages/stylist/src/lib.rs
@@ -13,66 +13,17 @@
 //!
 //! ### Yew Integration
 //!
-//! To enable yew integration. Enable feature `yew_integration` in `Cargo.toml`.
+//! To enable yew integration, enable the `yew_integration` feature in `Cargo.toml`.
 //!
-//! You can create a style and use it with yew like this:
-//!
-//! ```rust
-//! use stylist::yew::styled_component;
-//! use yew::prelude::*;
-//!
-//! #[styled_component(MyStyledComponent)]
-//! fn my_styled_component() -> Html {
-//!     html! {<div class={css!("color: red;")}>{"Hello World!"}</div>}
-//! }
-//! ```
-//!
-//! ### Procedural Macros
-//!
-//! To create a stylesheet, you can use [`style!`]:
-//!
-//! ```
-//! use stylist::style;
-//!
-//! let style = style!(
-//!     r#"
-//!         background-color: red;
-//!
-//!         .nested {
-//!             background-color: blue;
-//!             width: 100px
-//!         }
-//!     "#
-//! )
-//! .expect("Failed to mount style!");
-//! ```
-//!
-//! ### Style API
-//!
-//! If you want to parse a string into a style at runtime, you can use [`Style::new`]:
-//!
-//! ```rust
-//! use stylist::Style;
-//!
-//! let style = Style::new(
-//!     r#"
-//!         background-color: red;
-//!
-//!         .nested {
-//!             background-color: blue;
-//!             width: 100px
-//!         }
-//!     "#,
-//! )
-//! .expect("Failed to create style");
-//! ```
+//! For a detailed usage with yew, see the [`yew`](crate::yew) module.
 //!
 //! ### Syntax
 //!
-//! Everything that is not in a conditioned block will be applied to the Component
+//! Every declaration that is not in a qualified block will be applied to the Component
 //! the class of this style is applied to.
 //!
-//! You may also use Current Selector (`&`) in CSS selectors to denote the container element:
+//! You may also use `&` in CSS selectors to denote the generated class of the container
+//! element:
 //!
 //! ```css
 //! &:hover {
@@ -80,7 +31,7 @@
 //! }
 //! ```
 //!
-//! You can also use other CSS rules(such as: keyframes, supports and media):
+//! You can also use other CSS at-rules (such as: @keyframes, @supports and @media):
 //!
 //! ```css
 //! @keyframes mymove {
@@ -118,11 +69,35 @@
 //! There's theming example using
 //! [Yew Context API](https://github.com/futursolo/stylist-rs/tree/master/examples/yew-theme-context).
 //!
+//! ### Style API
+//!
+//! If you want to parse a string into a style at runtime, you need to enable the
+//! `parser` feature. You can then use [`Style::new`], passing a `str`, `String`
+//! or `Cow<'a, str>`:
+//!
+//! ```rust
+//! use stylist::Style;
+//!
+//! let style = Style::new(
+//!     r#"
+//!         background-color: red;
+//!
+//!         .nested {
+//!             background-color: blue;
+//!             width: 100px
+//!         }
+//!     "#,
+//! )
+//! .expect("Failed to create style");
+//! ```
+//!
 //! ## Features Flags
 //!
 //! - `macros`: Enabled by default, this flag enables procedural macro support.
 //! - `random`: Enabled by default, this flag uses `fastrand` crate to generate a random class name.
 //!   Disabling this flag will opt for a class name that is counter-based.
+//! - `parser`: Disabled by default, this flag enables runtime parsing of styles from strings. You
+//!   don't need to enable this to generate styles via the macros.
 //! - `yew_integration`: This flag enables yew integration, which implements
 //!   [`Classes`](::yew::html::Classes) for [`Style`] and provides a [`Global`](yew::Global)
 //!   component for applying global styles.

--- a/packages/stylist/src/style.rs
+++ b/packages/stylist/src/style.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::ops::Deref;
 use std::rc::Rc;
 
-#[cfg(all(debug_assertions, feature = "parser"))]
+#[cfg(all(debug_assertions, feature = "debug_parser"))]
 use stylist_core::ResultDisplay;
 
 use crate::ast::ToStyleStr;
@@ -178,7 +178,7 @@ impl Style {
 
         // We parse the style str again in debug mode to ensure that interpolated values are
         // not corrupting the stylesheet.
-        #[cfg(all(debug_assertions, feature = "parser"))]
+        #[cfg(all(debug_assertions, feature = "debug_parser"))]
         style_str
             .parse::<crate::ast::Sheet>()
             .expect_display("debug: Stylist failed to parse the style with interpolated values");
@@ -330,6 +330,7 @@ impl Style {
 }
 
 #[cfg(test)]
+#[cfg(feature = "parser")]
 mod tests {
     use super::*;
 

--- a/packages/stylist/src/yew/global.rs
+++ b/packages/stylist/src/yew/global.rs
@@ -4,7 +4,7 @@ use crate::manager::StyleManager;
 use crate::{GlobalStyle, StyleSource};
 use stylist_core::ResultDisplay;
 
-/// The properties for [`Global`] Component, please see its documentation for usage.
+/// The properties for the [`Global`] Component, please see its documentation for usage.
 #[derive(Properties, Clone, Debug, PartialEq)]
 pub struct GlobalProps {
     pub css: StyleSource,
@@ -12,33 +12,27 @@ pub struct GlobalProps {
 
 /// A Global Style that will be applied to `<html />` tag, inspired by [emotion](https://emotion.sh).
 ///
-/// The `css` attribute accepts type that implements
-/// [`IntoPropValue<StyleSource>`](yew::html::IntoPropValue) and
-/// panics if the string failed to be parsed into a stylesheet.
+/// The `css` attribute accepts a value of any type that implements
+/// [`IntoPropValue<StyleSource>`](yew::html::IntoPropValue). If you use the `parser`
+/// feature, this panics when supplying a string that fails to parse.
+///
+/// The style will be applied via the [`:root`](https://developer.mozilla.org/en-US/docs/Web/CSS/:root)
+/// pseudo-class, which has higher specificity than "simply" using the `html` selector.
 ///
 /// # Example:
 ///
 /// ```
+/// use stylist::css;
 /// use stylist::yew::Global;
 /// use yew::prelude::*;
 ///
-/// struct App;
-///
-/// impl Component for App {
-///     type Message = ();
-///     type Properties = ();
-///
-///     fn create(_ctx: &Context<Self>) -> Self {
-///         Self
-///     }
-///
-///     fn view(&self, _ctx: &Context<Self>) -> Html {
-///         html! {
-///             <>
-///                 <Global css="color: red;" />
-///                 <div>{"Hello World!"}</div>
-///             </>
-///         }
+/// #[function_component]
+/// fn App() -> Html {
+///     html! {
+///         <>
+///             <Global css={css!("color: red;")} />
+///             <div>{"Hello World!"}</div>
+///         </>
 ///     }
 /// }
 /// ```

--- a/packages/stylist/src/yew/hooks/use_media_query.rs
+++ b/packages/stylist/src/yew/hooks/use_media_query.rs
@@ -8,6 +8,7 @@ use crate::arch::window;
 /// This hook will return the result of whether the provided query matches and updates when the
 /// result changes.
 #[cfg(feature = "yew_use_media_query")]
+#[hook]
 pub fn use_media_query(query: &str) -> bool {
     let match_media = || {
         window()

--- a/packages/stylist/src/yew/hooks/use_style.rs
+++ b/packages/stylist/src/yew/hooks/use_style.rs
@@ -21,6 +21,7 @@ use crate::{Style, StyleSource};
 /// }
 /// ```
 #[cfg(feature = "yew_use_style")]
+#[hook]
 pub fn use_style<Css>(css: Css) -> Style
 where
     Css: TryInto<StyleSource>,

--- a/packages/stylist/src/yew/mod.rs
+++ b/packages/stylist/src/yew/mod.rs
@@ -1,4 +1,19 @@
 //! This module contains yew specific features.
+//!
+//! ## Usage in function components
+//!
+//! You can create a style and use it like this:
+//!
+//! ```rust
+//! use stylist::yew::use_style;
+//! use yew::prelude::*;
+//!
+//! #[function_component]
+//! fn MyStyledComponent() -> Html {
+//!     let style = use_style!("color: red;");
+//!     html! {<div class={style}>{"Hello World!"}</div>}
+//! }
+//! ```
 
 use yew::html::{Classes, IntoPropValue};
 

--- a/packages/stylist/src/yew/mod.rs
+++ b/packages/stylist/src/yew/mod.rs
@@ -33,8 +33,8 @@ use yew::html::{Classes, IntoPropValue};
 /// use stylist::yew::styled_component;
 /// use yew::prelude::*;
 ///
-/// #[styled_component(MyStyledComponent)]
-/// fn my_styled_component() -> Html {
+/// #[styled_component]
+/// fn MyStyledComponent() -> Html {
 ///     html! {<div class={css!("color: red;")}>{"Hello World!"}</div>}
 /// }
 /// ```

--- a/packages/stylist/tests/macro_integration_tests.rs
+++ b/packages/stylist/tests/macro_integration_tests.rs
@@ -4,5 +4,6 @@ fn test_macro_integrations() {
 
     t.compile_fail("tests/inline_integrations/*-fail.rs");
     t.compile_fail("tests/literal_integrations/*-fail.rs");
+    t.pass("tests/sc_integrations/*-pass.rs");
     t.compile_fail("tests/sc_integrations/*-fail.rs");
 }

--- a/packages/stylist/tests/sc_integrations/test_deduced_name-pass.rs
+++ b/packages/stylist/tests/sc_integrations/test_deduced_name-pass.rs
@@ -1,0 +1,13 @@
+use stylist::yew::styled_component;
+use yew::prelude::*;
+
+// See issue #90: get component identifier from function name
+#[styled_component]
+pub fn App() -> Html {
+    let _ = css!( background-color: grey; );
+    Html::default()
+}
+
+fn main() {
+    let _ = html! { <App /> };
+}


### PR DESCRIPTION
This PR tracks the changes necessary to update to the eventual yew 0.20 release.
Upgrades:
- Use `#[hook]` on hook integration
- Use `Renderer` and `features = ["csr"]` in the examples

Closes #87
Closes #90