### PR TITLE
Implement eager parsing, getting rid of lifetime on StyleSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.11.0
+
+### Breaking Changes:
+- `StyleSource` does not take a lifetime argument
+- Feature `parser`: `StyleSource` now eagerly parses its input.
+- Feature `parser`: The conversion from `str` have been changed to `TryFrom`
+  instead of `From`. If you're using `yew`, the `IntoPropValue<StyleSource>`
+  impls still exist, but now panic early during conversion.
+
+### Other Changes:
+- The `Style::new_*` API is more open for accepted types of the `Css` parameter.
+
 ## v0.10.0
 
 ### Breaking Changes:

--- a/examples/benchmarks/src/main.rs
+++ b/examples/benchmarks/src/main.rs
@@ -256,8 +256,9 @@ impl Component for Benchmarks {
 }
 
 impl YieldStyle for Benchmarks {
-    fn style_from(&self) -> StyleSource<'static> {
-        r#"
+    fn style_from(&self) -> StyleSource {
+        stylist::css!(
+            r#"
             display: flex;
             justify-content: center;
             align-items: center;
@@ -300,8 +301,8 @@ impl YieldStyle for Benchmarks {
             tbody tr:nth-child(even) {
                 background-color: rgb(240, 240, 240);
             }
-        "#
-        .into()
+            "#
+        )
     }
 }
 
@@ -357,8 +358,9 @@ impl Component for App {
 }
 
 impl YieldStyle for App {
-    fn style_from(&self) -> StyleSource<'static> {
-        r#"
+    fn style_from(&self) -> StyleSource {
+        stylist::css!(
+            r#"
             display: flex;
             justify-content: center;
             align-items: center;
@@ -373,8 +375,8 @@ impl YieldStyle for App {
                 height: 50px;
                 font-size: 20px;
             }
-        "#
-        .into()
+            "#
+        )
     }
 }
 

--- a/examples/yew-shadow/src/main.rs
+++ b/examples/yew-shadow/src/main.rs
@@ -117,8 +117,9 @@ impl Component for App {
 }
 
 impl YieldStyle for App {
-    fn style_from(&self) -> StyleSource<'static> {
-        r#"
+    fn style_from(&self) -> StyleSource {
+        stylist::css!(
+            r#"
             box-shadow: 0 0 5px 1px rgba(0, 0, 0, 0.7);
             height: 500px;
             width: 500px;
@@ -133,8 +134,8 @@ impl YieldStyle for App {
 
             flex-direction: column;
             background-color: white;
-        "#
-        .into()
+            "#
+        )
     }
 }
 

--- a/packages/stylist-core/src/error.rs
+++ b/packages/stylist-core/src/error.rs
@@ -19,6 +19,12 @@ pub enum Error {
     Web(Option<wasm_bindgen::JsValue>),
 }
 
+impl From<std::convert::Infallible> for Error {
+    fn from(infallible: std::convert::Infallible) -> Self {
+        match infallible {}
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub trait ResultDisplay<T> {

--- a/packages/stylist/src/lib.rs
+++ b/packages/stylist/src/lib.rs
@@ -76,7 +76,7 @@
 //! pub struct Component;
 //!
 //! impl YieldStyle for Component {
-//!     fn style_from(&self) -> StyleSource<'static> {
+//!     fn style_from(&self) -> StyleSource {
 //!         css!("color: red;")
 //!     }
 //! }

--- a/packages/stylist/src/style.rs
+++ b/packages/stylist/src/style.rs
@@ -153,13 +153,10 @@ impl Style {
     // and inlining
     fn create_impl(
         class_prefix: Cow<'static, str>,
-        css: StyleSource<'_>,
+        css: StyleSource,
         manager: StyleManager,
     ) -> Result<Self> {
-        #[cfg(all(debug_assertions, feature = "parser"))]
-        use crate::ast::Sheet;
-
-        let css = css.try_into_sheet()?;
+        let css = css.into_sheet();
 
         // Creates the StyleKey, return from registry if already cached.
         let key = StyleKey {
@@ -183,7 +180,7 @@ impl Style {
         // not corrupting the stylesheet.
         #[cfg(all(debug_assertions, feature = "parser"))]
         style_str
-            .parse::<Sheet>()
+            .parse::<crate::ast::Sheet>()
             .expect_display("debug: Stylist failed to parse the style with interpolated values");
 
         let new_style = Self {
@@ -215,9 +212,10 @@ impl Style {
     /// let style = Style::new("background-color: red;")?;
     /// # Ok::<(), stylist::Error>(())
     /// ```
-    pub fn new<'a, Css>(css: Css) -> Result<Self>
+    pub fn new<Css>(css: Css) -> Result<Self>
     where
-        Css: Into<StyleSource<'a>>,
+        Css: TryInto<StyleSource>,
+        crate::Error: From<Css::Error>,
     {
         Self::create(StyleManager::default().prefix(), css)
     }
@@ -232,34 +230,37 @@ impl Style {
     /// let style = Style::create("my-component", "background-color: red;")?;
     /// # Ok::<(), stylist::Error>(())
     /// ```
-    pub fn create<'a, N, Css>(class_prefix: N, css: Css) -> Result<Self>
+    pub fn create<N, Css>(class_prefix: N, css: Css) -> Result<Self>
     where
         N: Into<Cow<'static, str>>,
-        Css: Into<StyleSource<'a>>,
+        Css: TryInto<StyleSource>,
+        crate::Error: From<Css::Error>,
     {
-        Self::create_impl(class_prefix.into(), css.into(), StyleManager::default())
+        Self::create_with_manager(class_prefix, css, StyleManager::default())
     }
 
     /// Creates a new style from some parsable css with a default prefix using a custom
     /// manager.
-    pub fn new_with_manager<'a, Css, M>(css: Css, manager: M) -> Result<Self>
+    pub fn new_with_manager<Css, M>(css: Css, manager: M) -> Result<Self>
     where
-        Css: Into<StyleSource<'a>>,
+        Css: TryInto<StyleSource>,
+        crate::Error: From<Css::Error>,
         M: Into<StyleManager>,
     {
         let mgr = manager.into();
-        Self::create_impl(mgr.prefix(), css.into(), mgr.clone())
+        Self::create_with_manager(mgr.prefix(), css, mgr.clone())
     }
 
     /// Creates a new style with a custom class prefix from some parsable css using a custom
     /// manager.
-    pub fn create_with_manager<'a, N, Css, M>(class_prefix: N, css: Css, manager: M) -> Result<Self>
+    pub fn create_with_manager<N, Css, M>(class_prefix: N, css: Css, manager: M) -> Result<Self>
     where
         N: Into<Cow<'static, str>>,
-        Css: Into<StyleSource<'a>>,
+        Css: TryInto<StyleSource>,
+        crate::Error: From<Css::Error>,
         M: Into<StyleManager>,
     {
-        Self::create_impl(class_prefix.into(), css.into(), manager.into())
+        Self::create_impl(class_prefix.into(), css.try_into()?, manager.into())
     }
 
     /// Returns the class name for current style

--- a/packages/stylist/src/yew/global.rs
+++ b/packages/stylist/src/yew/global.rs
@@ -7,7 +7,7 @@ use stylist_core::ResultDisplay;
 /// The properties for [`Global`] Component, please see its documentation for usage.
 #[derive(Properties, Clone, Debug, PartialEq)]
 pub struct GlobalProps {
-    pub css: StyleSource<'static>,
+    pub css: StyleSource,
 }
 
 /// A Global Style that will be applied to `<html />` tag, inspired by [emotion](https://emotion.sh).
@@ -49,7 +49,7 @@ pub fn global(props: &GlobalProps) -> Html {
     #[derive(Debug, PartialEq)]
     struct GlobalDependents {
         manager: StyleManager,
-        css: StyleSource<'static>,
+        css: StyleSource,
     }
 
     use_effect_with_deps(

--- a/packages/stylist/src/yew/hooks/use_style.rs
+++ b/packages/stylist/src/yew/hooks/use_style.rs
@@ -22,9 +22,12 @@ use crate::{Style, StyleSource};
 /// ```
 #[cfg_attr(documenting, doc(cfg(feature = "yew_use_style")))]
 #[cfg(feature = "yew_use_style")]
-pub fn use_style<'a, Css: Into<StyleSource<'a>>>(css: Css) -> Style {
+pub fn use_style<Css>(css: Css) -> Style
+where
+    Css: TryInto<StyleSource>,
+    crate::Error: From<Css::Error>,
+{
     let mgr = use_context::<StyleManager>().unwrap_or_default();
-    let css = css.into();
 
     // It does not make sense to unmount a scoped style.
     Style::new_with_manager(css, mgr).expect_display("failed to create style")

--- a/packages/stylist/src/yew/mod.rs
+++ b/packages/stylist/src/yew/mod.rs
@@ -106,8 +106,8 @@ impl From<Style> for Classes {
     }
 }
 
-impl From<StyleSource<'_>> for Classes {
-    fn from(style_src: StyleSource<'_>) -> Self {
+impl From<StyleSource> for Classes {
+    fn from(style_src: StyleSource) -> Self {
         let mut classes = Self::new();
         #[cfg(all(debug_assertions, feature = "debug_style_locations"))]
         let location = style_src.location.clone();
@@ -119,8 +119,8 @@ impl From<StyleSource<'_>> for Classes {
     }
 }
 
-impl IntoPropValue<StyleSource<'static>> for Sheet {
-    fn into_prop_value(self) -> StyleSource<'static> {
+impl IntoPropValue<StyleSource> for Sheet {
+    fn into_prop_value(self) -> StyleSource {
         self.into()
     }
 }
@@ -131,22 +131,26 @@ mod feat_parser {
     use std::borrow::Cow;
 
     use super::*;
+    use stylist_core::ResultDisplay;
 
-    impl IntoPropValue<StyleSource<'static>> for String {
-        fn into_prop_value(self) -> StyleSource<'static> {
-            self.into()
+    impl IntoPropValue<StyleSource> for String {
+        fn into_prop_value(self) -> StyleSource {
+            self.try_into()
+                .expect_display("couldn't parse style string")
         }
     }
 
-    impl<'a> IntoPropValue<StyleSource<'a>> for &'a str {
-        fn into_prop_value(self) -> StyleSource<'a> {
-            self.into()
+    impl<'a> IntoPropValue<StyleSource> for &'a str {
+        fn into_prop_value(self) -> StyleSource {
+            self.try_into()
+                .expect_display("couldn't parse style string")
         }
     }
 
-    impl<'a> IntoPropValue<StyleSource<'a>> for Cow<'a, str> {
-        fn into_prop_value(self) -> StyleSource<'a> {
-            self.into()
+    impl<'a> IntoPropValue<StyleSource> for Cow<'a, str> {
+        fn into_prop_value(self) -> StyleSource {
+            self.try_into()
+                .expect_display("couldn't parse style string")
         }
     }
 }

--- a/packages/stylist/src/yield_style.rs
+++ b/packages/stylist/src/yield_style.rs
@@ -38,7 +38,7 @@ use crate::{Result, Style, StyleSource};
 /// }
 ///
 /// impl YieldStyle for MyStyledComponent {
-///     fn style_from(&self) -> StyleSource<'static> {
+///     fn style_from(&self) -> StyleSource {
 ///         css!("color: red;")
 ///     }
 /// }
@@ -54,7 +54,7 @@ pub trait YieldStyle {
     }
 
     /// Returns a type that can be turned into a [`Style`].
-    fn style_from(&self) -> StyleSource<'static>;
+    fn style_from(&self) -> StyleSource;
 
     /// Returns the generated style.
     ///


### PR DESCRIPTION
First PR angled towards #70. In evaluating the existing API, the lifetime of on `StyleSource`, existing only for the `parser` feature, has been removed. Raw css now gets parsed eagerly and early during conversion into a `StyleSource`. The feature gated `From<str>`, ... impls have been changed to `TryFrom<str>`, ...

This doesn't change the usage for the average user working with `css!` and other macros. Most of the time (even in existing API) the lifetime was assumed to be `'static` anyway.