### PR TITLE
Enforce rustfmt across the repository

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -4,6 +4,32 @@ name: Run Tests & Publishing
 on: [push, pull_request]
 
 jobs:
+  rustfmt:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          profile: minimal
+          components: rustfmt, clippy
+      - name: Run cargo fmt -- --check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+      - name: Run cargo clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          options: --all --all-features
+        env:
+          RUSTFLAGS: "--cfg releasing"
+
   test:
     name: Run Tests
     runs-on: ubuntu-latest
@@ -18,33 +44,10 @@ jobs:
         with:
           toolchain: stable
           override: true
-          components: rustfmt, clippy
           profile: minimal
 
       - name: Restore Rust Cache
         uses: Swatinem/rust-cache@v1
-
-      - name: Run cargo fmt -- --check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - name: Run cargo clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          options: --all --all-features
-        env:
-          RUSTFLAGS: "--cfg releasing"
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --all
-        env:
-          RUSTFLAGS: "--cfg releasing"
 
       - name: Setup trunk
         uses: jetli/trunk-action@v0.1.0

--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Restore Rust Cache
         uses: Swatinem/rust-cache@v1
 
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features --all
+        env:
+          RUSTFLAGS: "--cfg releasing"
+
       - name: Setup trunk
         uses: jetli/trunk-action@v0.1.0
         with:

--- a/packages/stylist-core/src/ast/block.rs
+++ b/packages/stylist-core/src/ast/block.rs
@@ -15,8 +15,8 @@ use super::{RuleBlockContent, Selector, StyleContext, ToStyleStr};
 pub struct Block {
     /// Selector(s) for Current Block
     ///
-    /// If the value is set as [`&[]`], it signals to substitute with the classname generated for the
-    /// [`Sheet`](super::Sheet) in which this is contained.
+    /// If the value is set as [`&[]`], it signals to substitute with the classname generated for
+    /// the [`Sheet`](super::Sheet) in which this is contained.
     pub condition: Cow<'static, [Selector]>,
     pub content: Cow<'static, [RuleBlockContent]>,
 }

--- a/packages/stylist-core/src/error.rs
+++ b/packages/stylist-core/src/error.rs
@@ -30,7 +30,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub trait ResultDisplay<T> {
     /// Returns the contained Ok value, consuming the self value, panic when `Result` is `Err`.
     fn unwrap_display(self) -> T;
-    /// Returns the contained Ok value, consuming the self value, panic with message when `Result` is `Err`.
+    /// Returns the contained Ok value, consuming the self value, panic with message when `Result`
+    /// is `Err`.
     fn expect_display(self, msg: &str) -> T;
 }
 

--- a/packages/stylist-core/src/lib.rs
+++ b/packages/stylist-core/src/lib.rs
@@ -18,8 +18,7 @@ mod parser;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ast::Sheet;
-    use ast::ToStyleStr;
+    use ast::{Sheet, ToStyleStr};
 
     #[test]
     fn test_scoped_complex() {

--- a/packages/stylist-core/src/parser.rs
+++ b/packages/stylist-core/src/parser.rs
@@ -218,7 +218,6 @@ impl Parser {
     }
 
     /// Parse a quoted string.
-    ///
     // TODO: Parse ' quoted strings.
     fn string(i: &str) -> IResult<&str, &str, VerboseError<&str>> {
         let escaped_char = traced_context("EscapedChar", recognize(preceded(tag("\\"), anychar)));
@@ -232,7 +231,6 @@ impl Parser {
     }
 
     /// Parse a string interpolation.
-    ///
     // TODO: Handle escaping.
     fn interpolation(i: &str) -> IResult<&str, &str, VerboseError<&str>> {
         traced_context(
@@ -249,7 +247,6 @@ impl Parser {
     }
 
     /// Parse a selector.
-    ///
     // TODO: Parse selector properly.
     fn selector(i: &str) -> IResult<&str, Selector, VerboseError<&str>> {
         traced_context(

--- a/packages/stylist-macros/src/inline/component_value/function_token.rs
+++ b/packages/stylist-macros/src/inline/component_value/function_token.rs
@@ -1,11 +1,9 @@
-use super::{super::css_ident::CssIdent, ComponentValue};
+use super::super::css_ident::CssIdent;
+use super::ComponentValue;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{
-    parenthesized,
-    parse::{Parse, ParseBuffer, Result as ParseResult},
-    token,
-};
+use syn::parse::{Parse, ParseBuffer, Result as ParseResult};
+use syn::{parenthesized, token};
 
 // Css-syntax parses like
 // v----v function token

--- a/packages/stylist-macros/src/inline/component_value/interpolated_expression.rs
+++ b/packages/stylist-macros/src/inline/component_value/interpolated_expression.rs
@@ -1,11 +1,8 @@
 use crate::output::OutputFragment;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{
-    braced,
-    parse::{Parse, ParseBuffer, Result as ParseResult},
-    token, Expr,
-};
+use syn::parse::{Parse, ParseBuffer, Result as ParseResult};
+use syn::{braced, token, Expr};
 
 #[derive(Debug, Clone)]
 pub struct InterpolatedExpression {

--- a/packages/stylist-macros/src/inline/component_value/mod.rs
+++ b/packages/stylist-macros/src/inline/component_value/mod.rs
@@ -2,8 +2,8 @@
 //! You can think of this as being either a block, a function or a preserved (atomic) token.
 //!
 //! This guides our inline parser as follows:
-//! - first re-tokenize the TokenStream into a stream of ComponentValues. For this step see
-//!   also [`ComponentValueStream`].
+//! - first re-tokenize the TokenStream into a stream of ComponentValues. For this step see also
+//!   [`ComponentValueStream`].
 //! - parse and verify the component values into blocks, @-rules and attributes.
 //!
 //! In general, only a parse error in the first step should be fatal and panic immediately,
@@ -13,10 +13,8 @@ use super::css_ident::CssIdent;
 use crate::output::OutputFragment;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{
-    parse::{Error as ParseError, Parse, ParseBuffer, Result as ParseResult},
-    token, Lit,
-};
+use syn::parse::{Error as ParseError, Parse, ParseBuffer, Result as ParseResult};
+use syn::{token, Lit};
 
 mod function_token;
 mod interpolated_expression;
@@ -89,8 +87,9 @@ impl ComponentValue {
 
             Self::Block(ref m) => {
                 if let BlockKind::Braced(_) = m.kind {
-                    // this kind of block is not supposed to appear in @-rule preludes, block qualifiers
-                    // or attribute values and as such should not get emitted
+                    // this kind of block is not supposed to appear in @-rule preludes, block
+                    // qualifiers or attribute values and as such should not get
+                    // emitted
                     unreachable!("braced blocks should not get reified");
                 }
                 let (start, end) = m.kind.surround_tokens();

--- a/packages/stylist-macros/src/inline/component_value/simple_block.rs
+++ b/packages/stylist-macros/src/inline/component_value/simple_block.rs
@@ -1,11 +1,8 @@
 use super::ComponentValue;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{
-    braced, bracketed, parenthesized,
-    parse::{Parse, ParseBuffer, Result as ParseResult},
-    token,
-};
+use syn::parse::{Parse, ParseBuffer, Result as ParseResult};
+use syn::{braced, bracketed, parenthesized, token};
 
 #[derive(Debug, Clone)]
 pub enum BlockKind {

--- a/packages/stylist-macros/src/inline/css_ident.rs
+++ b/packages/stylist-macros/src/inline/css_ident.rs
@@ -1,11 +1,9 @@
 use proc_macro2::{Punct, Spacing, TokenStream};
 use quote::ToTokens;
 use std::fmt::{Display, Formatter};
-use syn::{
-    ext::IdentExt,
-    parse::{Parse, ParseBuffer, Result as ParseResult},
-    token, Ident,
-};
+use syn::ext::IdentExt;
+use syn::parse::{Parse, ParseBuffer, Result as ParseResult};
+use syn::{token, Ident};
 
 syn::custom_punctuation!(DoubleSub, --);
 

--- a/packages/stylist-macros/src/inline/parse/attribute.rs
+++ b/packages/stylist-macros/src/inline/parse/attribute.rs
@@ -1,8 +1,6 @@
-use syn::{
-    parse::{Error as ParseError, Parse, ParseBuffer, Result as ParseResult},
-    spanned::Spanned,
-    token,
-};
+use syn::parse::{Error as ParseError, Parse, ParseBuffer, Result as ParseResult};
+use syn::spanned::Spanned;
+use syn::token;
 
 use super::{fragment_spacing, IntoOutputContext};
 use crate::inline::component_value::{

--- a/packages/stylist-macros/src/inline/parse/qualifier.rs
+++ b/packages/stylist-macros/src/inline/parse/qualifier.rs
@@ -1,15 +1,12 @@
-use super::{
-    super::component_value::{ComponentValue, ComponentValueStream, PreservedToken},
-    fragment_spacing, IntoOutputContext,
-};
-use crate::{output::OutputSelector, spacing_iterator::SpacedIterator};
+use super::super::component_value::{ComponentValue, ComponentValueStream, PreservedToken};
+use super::{fragment_spacing, IntoOutputContext};
+use crate::output::OutputSelector;
+use crate::spacing_iterator::SpacedIterator;
 use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{
-    parse::{Error as ParseError, Parse, ParseBuffer, Result as ParseResult},
-    token,
-};
+use syn::parse::{Error as ParseError, Parse, ParseBuffer, Result as ParseResult};
+use syn::token;
 
 #[derive(Debug, Clone, Default)]
 pub struct CssBlockQualifier {

--- a/packages/stylist-macros/src/inline/parse/rule.rs
+++ b/packages/stylist-macros/src/inline/parse/rule.rs
@@ -1,19 +1,11 @@
-use syn::{
-    parse::{Error as ParseError, Parse, ParseBuffer, Result as ParseResult},
-    token,
-};
+use syn::parse::{Error as ParseError, Parse, ParseBuffer, Result as ParseResult};
+use syn::token;
 
-use super::{
-    super::{
-        component_value::{ComponentValue, ComponentValueStream},
-        css_ident::CssIdent,
-    },
-    fragment_spacing, CssScope, IntoOutputContext,
-};
-use crate::{
-    output::{OutputFragment, OutputRule},
-    spacing_iterator::SpacedIterator,
-};
+use super::super::component_value::{ComponentValue, ComponentValueStream};
+use super::super::css_ident::CssIdent;
+use super::{fragment_spacing, CssScope, IntoOutputContext};
+use crate::output::{OutputFragment, OutputRule};
+use crate::spacing_iterator::SpacedIterator;
 
 #[derive(Debug)]
 pub enum CssAtRuleContent {
@@ -41,7 +33,8 @@ impl Parse for CssAtRule {
         let mut errors = vec![];
 
         // Recognize the type of @-rule
-        // TODO: be sensitive to this detected type when validating the prelude and contained attributes
+        // TODO: be sensitive to this detected type when validating the prelude and contained
+        // attributes
         if !["media", "supports"].contains(&name.to_output_string().as_str()) {
             errors.push(ParseError::new_spanned(
                 &name,

--- a/packages/stylist-macros/src/inline/parse/scope.rs
+++ b/packages/stylist-macros/src/inline/parse/scope.rs
@@ -1,10 +1,7 @@
 use std::mem;
 
-use syn::{
-    braced,
-    parse::{Error as ParseError, Parse, ParseBuffer, Result as ParseResult},
-    token,
-};
+use syn::parse::{Error as ParseError, Parse, ParseBuffer, Result as ParseResult};
+use syn::{braced, token};
 
 use super::{CssAttribute, CssQualifiedRule, CssScopeContent, IntoOutputContext};
 use crate::output::OutputRuleBlockContent;

--- a/packages/stylist-macros/src/inline/parse/scope_content.rs
+++ b/packages/stylist-macros/src/inline/parse/scope_content.rs
@@ -1,10 +1,8 @@
 use itertools::Itertools;
 use syn::parse::{Parse, ParseBuffer, Result as ParseResult};
 
-use super::{
-    super::component_value::{ComponentValue, ComponentValueStream, PreservedToken},
-    CssAtRule, CssAttribute, CssQualifiedRule,
-};
+use super::super::component_value::{ComponentValue, ComponentValueStream, PreservedToken};
+use super::{CssAtRule, CssAttribute, CssQualifiedRule};
 
 #[derive(Debug)]
 pub enum CssScopeContent {

--- a/packages/stylist-macros/src/literal/fstring.rs
+++ b/packages/stylist-macros/src/literal/fstring.rs
@@ -1,13 +1,11 @@
-use nom::{
-    branch::alt,
-    bytes::complete::{is_not, tag, take_while},
-    character::complete::{alpha1, alphanumeric1},
-    combinator::{all_consuming, cut, map, opt, recognize},
-    error::{context, convert_error, ErrorKind, ParseError, VerboseError},
-    multi::many0,
-    sequence::{delimited, preceded},
-    IResult,
-};
+use nom::branch::alt;
+use nom::bytes::complete::{is_not, tag, take_while};
+use nom::character::complete::{alpha1, alphanumeric1};
+use nom::combinator::{all_consuming, cut, map, opt, recognize};
+use nom::error::{context, convert_error, ErrorKind, ParseError, VerboseError};
+use nom::multi::many0;
+use nom::sequence::{delimited, preceded};
+use nom::IResult;
 use stylist_core::{Error, Result};
 
 #[cfg(test)]

--- a/packages/stylist-macros/src/literal/to_output_with_args.rs
+++ b/packages/stylist-macros/src/literal/to_output_with_args.rs
@@ -9,7 +9,8 @@ use crate::output::{
     OutputScopeContent, OutputSelector, OutputSheet,
 };
 
-use super::{argument::Argument, fstring};
+use super::argument::Argument;
+use super::fstring;
 
 pub(crate) trait ToOutputWithArgs {
     type Output;

--- a/packages/stylist-macros/src/output/cow_str.rs
+++ b/packages/stylist-macros/src/output/cow_str.rs
@@ -1,7 +1,8 @@
 use super::{Reify, ReifyContext};
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
-use syn::{spanned::Spanned, LitStr};
+use syn::spanned::Spanned;
+use syn::LitStr;
 
 #[derive(Debug)]
 pub enum OutputCowString {

--- a/packages/stylist-macros/src/output/str_frag.rs
+++ b/packages/stylist-macros/src/output/str_frag.rs
@@ -1,19 +1,19 @@
 use proc_macro2::{Delimiter, TokenStream};
 use quote::quote;
-use syn::{spanned::Spanned, Expr, ExprLit, Lit};
+use syn::spanned::Spanned;
+use syn::{Expr, ExprLit, Lit};
 
 use super::{OutputCowString, Reify, ReifyContext};
-use crate::{
-    inline::{component_value::PreservedToken, css_ident::CssIdent},
-    literal::argument::Argument,
-};
+use crate::inline::component_value::PreservedToken;
+use crate::inline::css_ident::CssIdent;
+use crate::literal::argument::Argument;
 
 #[derive(Debug, Clone)]
 pub enum OutputFragment {
     Expr(Expr),
     Arg(Argument),
     Token(PreservedToken),
-    Delimiter(Delimiter, /*start:*/ bool),
+    Delimiter(Delimiter, /* start: */ bool),
     Str(String),
 }
 

--- a/packages/stylist-macros/src/styled_component.rs
+++ b/packages/stylist-macros/src/styled_component.rs
@@ -2,8 +2,7 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
-use syn::parse_macro_input;
-use syn::{Item, ItemFn};
+use syn::{parse_macro_input, Item, ItemFn};
 
 use super::styled_component_impl::{styled_component_impl_impl, HookLike};
 

--- a/packages/stylist-macros/src/styled_component_impl.rs
+++ b/packages/stylist-macros/src/styled_component_impl.rs
@@ -2,8 +2,7 @@
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
-use syn::parse_macro_input;
-use syn::{Ident, Item, ItemFn};
+use syn::{parse_macro_input, Ident, Item, ItemFn};
 
 #[derive(Debug)]
 pub struct HookLike {

--- a/packages/stylist/src/ast.rs
+++ b/packages/stylist/src/ast.rs
@@ -24,16 +24,17 @@
 
 /// A procedural macro that parses a string literal or an inline stylesheet into a [`Sheet`].
 ///
-/// Please consult the documentation of the [`macros`](crate::macros) module for the supported syntax of this macro.
+/// Please consult the documentation of the [`macros`](crate::macros) module for the supported
+/// syntax of this macro.
 ///
 /// # Warning
 ///
 /// Use of this macro is discouraged.
 ///
-/// Any place that accepts the output of this macro also accepts the output of [`css!`](crate::css).
+/// Any place that accepts the output of this macro also accepts the output of
+/// [`css!`](crate::css).
 ///
 /// Use [`css!`](crate::css) unless you know what you are doing.
-///
 #[cfg_attr(documenting, doc(cfg(feature = "macros")))]
 #[cfg(feature = "macros")]
 pub use stylist_macros::sheet;

--- a/packages/stylist/src/global_style.rs
+++ b/packages/stylist/src/global_style.rs
@@ -128,7 +128,8 @@ impl GlobalStyle {
 
     /// Unregister current style from style registry.
     ///
-    /// After calling this method, the style will be unmounted from DOM after all its clones are freed.
+    /// After calling this method, the style will be unmounted from DOM after all its clones are
+    /// freed.
     pub fn unregister(&self) {
         let reg = self.inner.manager().get_registry();
         let mut reg = reg.borrow_mut();

--- a/packages/stylist/src/lib.rs
+++ b/packages/stylist/src/lib.rs
@@ -1,7 +1,7 @@
-#![deny(clippy::all)]
 #![deny(missing_debug_implementations)]
 #![deny(unsafe_code)]
 #![deny(non_snake_case)]
+#![deny(clippy::all)]
 #![deny(clippy::cognitive_complexity)]
 #![cfg_attr(documenting, feature(doc_cfg))]
 #![cfg_attr(any(releasing, not(debug_assertions)), deny(dead_code, unused_imports))]
@@ -17,8 +17,8 @@
 //! You can create a style and use it with yew like this:
 //!
 //! ```rust
-//! use yew::prelude::*;
 //! use stylist::yew::styled_component;
+//! use yew::prelude::*;
 //!
 //! #[styled_component(MyStyledComponent)]
 //! fn my_styled_component() -> Html {
@@ -42,7 +42,8 @@
 //!             width: 100px
 //!         }
 //!     "#
-//! ).expect("Failed to mount style!");
+//! )
+//! .expect("Failed to mount style!");
 //! ```
 //!
 //! ### Style API
@@ -61,7 +62,8 @@
 //!             width: 100px
 //!         }
 //!     "#,
-//! ).expect("Failed to create style");
+//! )
+//! .expect("Failed to create style");
 //! ```
 //!
 //! ### Syntax
@@ -118,70 +120,38 @@
 //! ## Features Flags
 //!
 //! - `macros`: Enabled by default, this flag enables procedural macro support.
-//! - `random`: Enabled by default, this flag uses `fastrand` crate to generate a random
-//!   class name. Disabling this flag will opt for a class name that is counter-based.
-//! - `yew_integration`: This flag enables yew integration, which implements [`Classes`](::yew::html::Classes) for
-//!   [`Style`] and provides a [`Global`](yew::Global) component for applying global styles.
+//! - `random`: Enabled by default, this flag uses `fastrand` crate to generate a random class name.
+//!   Disabling this flag will opt for a class name that is counter-based.
+//! - `yew_integration`: This flag enables yew integration, which implements
+//!   [`Classes`](::yew::html::Classes) for [`Style`] and provides a [`Global`](yew::Global)
+//!   component for applying global styles.
 
 #[cfg(any(feature = "yew_use_media_query", target_arch = "wasm32"))]
 mod arch;
-
-pub mod manager;
-mod registry;
-
 pub mod ast;
 mod global_style;
+#[cfg_attr(documenting, doc(cfg(feature = "macros")))]
+#[cfg(feature = "macros")]
+pub mod macros;
+pub mod manager;
+mod registry;
 mod style;
 mod style_src;
 mod utils;
-
-pub use global_style::GlobalStyle;
-pub use style::Style;
-pub use style_src::StyleSource;
-
 #[cfg_attr(documenting, doc(cfg(feature = "yew")))]
 #[cfg(feature = "yew")]
 pub mod yew;
 
-#[cfg_attr(documenting, doc(cfg(feature = "macros")))]
-#[cfg(feature = "macros")]
-pub mod macros;
-
-/// A procedural macro that parses a string literal or an inline stylesheet into a [`Style`].
+pub use global_style::GlobalStyle;
+pub use style::Style;
+pub use style_src::StyleSource;
+#[doc(inline)]
+pub use stylist_core::{Error, Result};
+/// A procedural macro that parses a string literal or an inline stylesheet into a
+/// [`StyleSource`].
 ///
-/// Please consult the documentation of the [`macros`] module for the supported syntax of this macro.
-///
-/// # Example
-///
-/// ```
-/// use stylist::style;
-///
-/// // Returns a Style instance.
-/// let style = style!("color: red;");
-/// ```
-#[cfg_attr(documenting, doc(cfg(feature = "macros")))]
-#[cfg(feature = "macros")]
-pub use stylist_macros::style;
-
-/// A procedural macro that parses a string literal or an inline stylesheet into a [`GlobalStyle`].
-///
-/// Please consult the documentation of the [`macros`] module for the supported syntax of this macro.
-///
-/// # Example
-///
-/// ```
-/// use stylist::global_style;
-///
-/// // Returns a GlobalStyle instance.
-/// let style = global_style!("color: red;");
-/// ```
-#[cfg_attr(documenting, doc(cfg(feature = "macros")))]
-#[cfg(feature = "macros")]
-pub use stylist_macros::global_style;
-
-/// A procedural macro that parses a string literal or an inline stylesheet into a [`StyleSource`].
-///
-/// Please consult the documentation of the [`macros`] module for the supported syntax of this macro.
+/// Please consult the documentation of the [`macros`] module for the supported syntax of this
+/// macro.
 ///
 /// # Example
 ///
@@ -196,6 +166,36 @@ pub use stylist_macros::global_style;
 #[cfg_attr(documenting, doc(cfg(feature = "macros")))]
 #[cfg(feature = "macros")]
 pub use stylist_macros::css;
-
-#[doc(inline)]
-pub use stylist_core::{Error, Result};
+/// A procedural macro that parses a string literal or an inline stylesheet into a
+/// [`GlobalStyle`].
+///
+/// Please consult the documentation of the [`macros`] module for the supported syntax of this
+/// macro.
+///
+/// # Example
+///
+/// ```
+/// use stylist::global_style;
+///
+/// // Returns a GlobalStyle instance.
+/// let style = global_style!("color: red;");
+/// ```
+#[cfg_attr(documenting, doc(cfg(feature = "macros")))]
+#[cfg(feature = "macros")]
+pub use stylist_macros::global_style;
+/// A procedural macro that parses a string literal or an inline stylesheet into a [`Style`].
+///
+/// Please consult the documentation of the [`macros`] module for the supported syntax of this
+/// macro.
+///
+/// # Example
+///
+/// ```
+/// use stylist::style;
+///
+/// // Returns a Style instance.
+/// let style = style!("color: red;");
+/// ```
+#[cfg_attr(documenting, doc(cfg(feature = "macros")))]
+#[cfg(feature = "macros")]
+pub use stylist_macros::style;

--- a/packages/stylist/src/macros.rs
+++ b/packages/stylist/src/macros.rs
@@ -9,7 +9,8 @@
 //! The first argument of this syntax is a string literal followed by an argument list. This macro
 //! will replace `${arg}` with the argument in the argument list when creating the AST.
 //!
-//! This syntax supports interpolation on values of style attributes, selectors, `@supports` and `@media` rules.
+//! This syntax supports interpolation on values of style attributes, selectors, `@supports` and
+//! `@media` rules.
 //!
 //! Interpolated strings are denoted with `${ident}` and any type that implements [`Display`] can be
 //! used as value. Only named argument are supported at this moment.
@@ -33,7 +34,7 @@
 //! ## Example
 //!
 //! ```
-//! use stylist::{Style, css};
+//! use stylist::{css, Style};
 //! use yew::prelude::*;
 //!
 //! let s = css!(
@@ -74,40 +75,43 @@
 //!
 //! You may also directly inline a stylesheet in the macro.
 //!
-//! Like in string interpolation syntax, interpolated values are allowed in most places through the `${expr}`
-//! syntax. In distinction, the braces contain a rust expression of any type implementing [`Display`]
-//! will be evaluated in the surrounding context.
+//! Like in string interpolation syntax, interpolated values are allowed in most places through the
+//! `${expr}` syntax. In distinction, the braces contain a rust expression of any type implementing
+//! [`Display`] will be evaluated in the surrounding context.
 //!
 //! ## Known Limitations
 //!
 //! ### Dimensions
 //!
-//! Due to the tokenizer of the Rust complier, there are some quirks with literals. For example, `4em` would be
-//! tokenized as a floating point literal with a missing exponent and a suffix of `m`. To work around this issue, use
-//! string interpolation as in `${"4em"}`. Similarly, some color hash-tokens like `#44444e` as misinterpreted,
-//! use the same workaround here: `${"#44444e"}`.
+//! Due to the tokenizer of the Rust complier, there are some quirks with literals. For example,
+//! `4em` would be tokenized as a floating point literal with a missing exponent and a suffix of
+//! `m`. To work around this issue, use string interpolation as in `${"4em"}`. Similarly, some color
+//! hash-tokens like `#44444e` as misinterpreted, use the same workaround here: `${"#44444e"}`.
 //!
 //! ### Descendant Selectors
 //!
-//! The stable Rust tokenizer also currently offers no way to inspect whitespace between tokens, as tracked in
-//! [the Span inspection API issue](https://github.com/rust-lang/rust/issues/54725). This means that, e.g. the two
-//! selectors `.class-a.class-b` and `.class-a .class-b` can not be differentiated. **The macro errs on side of the
-//! former input without any spaces.** If you meant to write the latter, use `.class-a *.class-b`.
+//! The stable Rust tokenizer also currently offers no way to inspect whitespace between tokens, as
+//! tracked in [the Span inspection API issue](https://github.com/rust-lang/rust/issues/54725). This means that, e.g. the two
+//! selectors `.class-a.class-b` and `.class-a .class-b` can not be differentiated. **The macro errs
+//! on side of the former input without any spaces.** If you meant to write the latter, use
+//! `.class-a *.class-b`.
 //!
-//! To be more specific, a space is inserted between two tokens `L R` iff (regardless of the space being present in the macro input):
-//! - `L` is either a closing bracket `)}]`, an identifier `red`, a literal string `"\e600"` or number `3px`, or the '*' character.
+//! To be more specific, a space is inserted between two tokens `L R` iff (regardless of the space
+//! being present in the macro input):
+//! - `L` is either a closing bracket `)}]`, an identifier `red`, a literal string `"\e600"` or
+//!   number `3px`, or the '*' character.
 //! - `R` is either an identifier, a literal string or number, the '*' or '#' character.
 //! Spacing around interpolation is ignored regardless.
 //!
-//! Be aware that the above is subject to change once the Span API is stabilized. To avoid future rewriting, use spacing
-//! in your source code that follows the same rules. Refer to the associated [bug report](https://github.com/futursolo/stylist-rs/issues/41)
+//! Be aware that the above is subject to change once the Span API is stabilized. To avoid future
+//! rewriting, use spacing in your source code that follows the same rules. Refer to the associated [bug report](https://github.com/futursolo/stylist-rs/issues/41)
 //! to discuss this limitation and offer additional suggestions
 //!
 //! ### Identifier (Edition 2021)
 //!
 //! In Rust edition 2021, you cannot have an identifier before `#`.
-//! In other words, a selector like `.class#id` will no longer compile in Rust edition 2021 (See: [Reserving
-//! Syntax](https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html) in Rust
+//! In other words, a selector like `.class#id` will no longer compile in Rust edition 2021 (See:
+//! [Reserving Syntax](https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html) in Rust
 //! 2021 Edition Guide).
 //!
 //! Stylist previously treats them as if there is a descendant selector in between (`.class#id` is
@@ -157,9 +161,9 @@
 //! ## Security Notice
 //!
 //! Stylist currently does not check or escape the content of interpolated strings. It is possible
-//! to pass invalid strings that would result in an invalid stylesheet. In debug mode, if feature `parser` is
-//! enabled, Stylist will attempt to parse the stylesheet again after interpolated strings are
-//! substituted with its actual value to check if the final stylesheet is valid.
+//! to pass invalid strings that would result in an invalid stylesheet. In debug mode, if feature
+//! `parser` is enabled, Stylist will attempt to parse the stylesheet again after interpolated
+//! strings are substituted with its actual value to check if the final stylesheet is valid.
 //!
 //! [string literal]: #string-literal
 //! [inline]: #inline

--- a/packages/stylist/src/manager.rs
+++ b/packages/stylist/src/manager.rs
@@ -1,7 +1,8 @@
 //! Customise behaviour of Styles.
 //!
 //! This module contains [`StyleManager`] which can be used for customising
-//! mounting point / mounting behaviour for styles (when rendering contents into a `ShadowRoot` or an `<iframe />`).
+//! mounting point / mounting behaviour for styles (when rendering contents into a `ShadowRoot` or
+//! an `<iframe />`).
 //!
 //! This is an advanced feature and most of the time you don't need to use it.
 

--- a/packages/stylist/src/style.rs
+++ b/packages/stylist/src/style.rs
@@ -311,7 +311,8 @@ impl Style {
 
     /// Unregister current style from style registry.
     ///
-    /// After calling this method, the style will be unmounted from DOM after all its clones are freed.
+    /// After calling this method, the style will be unmounted from DOM after all its clones are
+    /// freed.
     ///
     /// # Note
     ///

--- a/packages/stylist/src/style_src.rs
+++ b/packages/stylist/src/style_src.rs
@@ -11,8 +11,9 @@ use crate::Style;
 /// You can also get a StyleSource instance from a string or a [`Sheet`] by calling `.into()`.
 ///
 /// ```rust
+/// use stylist::yew::Global;
+/// use stylist::{css, StyleSource};
 /// use yew::prelude::*;
-/// use stylist::{css, StyleSource, yew::Global};
 ///
 /// let s: StyleSource = css!("color: red;");
 ///

--- a/packages/stylist/src/yew/global.rs
+++ b/packages/stylist/src/yew/global.rs
@@ -19,8 +19,8 @@ pub struct GlobalProps {
 /// # Example:
 ///
 /// ```
-/// use yew::prelude::*;
 /// use stylist::yew::Global;
+/// use yew::prelude::*;
 ///
 /// struct App;
 ///

--- a/packages/stylist/src/yew/hooks/use_media_query.rs
+++ b/packages/stylist/src/yew/hooks/use_media_query.rs
@@ -5,8 +5,8 @@ use crate::arch::window;
 
 /// A hook to provide media query.
 ///
-/// This hook will return the result of whether the provided query matches and updates when the result
-/// changes.
+/// This hook will return the result of whether the provided query matches and updates when the
+/// result changes.
 #[cfg_attr(documenting, doc(cfg(feature = "yew_use_media_query")))]
 #[cfg(feature = "yew_use_media_query")]
 pub fn use_media_query(query: &str) -> bool {

--- a/packages/stylist/src/yew/hooks/use_style.rs
+++ b/packages/stylist/src/yew/hooks/use_style.rs
@@ -10,14 +10,14 @@ use crate::{Style, StyleSource};
 /// # Example
 ///
 /// ```
-/// use yew::prelude::*;
 /// use stylist::yew::use_style;
+/// use yew::prelude::*;
 ///
 /// #[function_component(Comp)]
 /// fn comp() -> Html {
 ///     // Returns a Style instance.
 ///     let style = use_style("color: red;");
-///     html!{<div class={style}>{"Hello world!"}</div>}
+///     html! {<div class={style}>{"Hello world!"}</div>}
 /// }
 /// ```
 #[cfg_attr(documenting, doc(cfg(feature = "yew_use_style")))]

--- a/packages/stylist/src/yew/mod.rs
+++ b/packages/stylist/src/yew/mod.rs
@@ -15,8 +15,8 @@ use yew::html::{Classes, IntoPropValue};
 /// ```rust
 /// use std::borrow::Cow;
 ///
-/// use yew::prelude::*;
 /// use stylist::yew::styled_component;
+/// use yew::prelude::*;
 ///
 /// #[styled_component(MyStyledComponent)]
 /// fn my_styled_component() -> Html {
@@ -43,8 +43,8 @@ pub use stylist_macros::styled_component;
 /// # Example:
 ///
 /// ```rust
-/// use yew::prelude::*;
 /// use stylist::yew::styled_component_impl;
+/// use yew::prelude::*;
 ///
 /// // Equivalent to #[styled_component(MyStyledComponent)]
 /// // This usage is discouraged, prefer `styled_component`
@@ -60,21 +60,23 @@ pub use stylist_macros::styled_component;
 #[cfg(feature = "macros")]
 pub use stylist_macros::styled_component_impl;
 
-/// A procedural macro hook that parses a string literal or an inline stylesheet to create auto updating [`Style`]s.
+/// A procedural macro hook that parses a string literal or an inline stylesheet to create auto
+/// updating [`Style`]s.
 ///
-/// Please consult the documentation of the [`macros`](crate::macros) module for the supported syntax of this macro.
+/// Please consult the documentation of the [`macros`](crate::macros) module for the supported
+/// syntax of this macro.
 ///
 /// # Example
 ///
 /// ```
-/// use yew::prelude::*;
 /// use stylist::yew::use_style;
+/// use yew::prelude::*;
 ///
 /// #[function_component(Comp)]
 /// fn comp() -> Html {
 ///     // Returns a Style instance.
 ///     let style = use_style!("color: red;");
-///     html!{<div class={style}>{"Hello world!"}</div>}
+///     html! {<div class={style}>{"Hello world!"}</div>}
 /// }
 /// ```
 #[cfg_attr(documenting, doc(cfg(feature = "yew_use_style")))]

--- a/packages/stylist/src/yew/provider.rs
+++ b/packages/stylist/src/yew/provider.rs
@@ -14,15 +14,18 @@ pub struct ManagerProviderProps {
 /// # Example:
 ///
 /// ```
-/// use yew::prelude::*;
-/// use stylist::yew::ManagerProvider;
 /// use stylist::manager::StyleManager;
+/// use stylist::yew::ManagerProvider;
+/// use yew::prelude::*;
 ///
 /// #[function_component(App)]
 /// fn app() -> Html {
-///     let mgr = use_state(
-///         || StyleManager::builder().prefix("my-styles".into()).build().unwrap()
-///     );
+///     let mgr = use_state(|| {
+///         StyleManager::builder()
+///             .prefix("my-styles".into())
+///             .build()
+///             .unwrap()
+///     });
 ///
 ///     let children = Html::default();
 ///     html! {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,9 @@
+edition = "2021"
+
+format_code_in_doc_comments = true
+wrap_comments = true
+comment_width = 100                # same as default max_width
+normalize_doc_attributes = true
+normalize_comments = true
+
+imports_granularity = "Module"


### PR DESCRIPTION
For code style, enforce a `rustfmt.toml` style across the repository. No changes to functionality.