### PR TITLE
Add impls for `IntoPropValue<Classes>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.10.1
+
+### Other Changes:
+- Added an impl of `IntoPropValue<Classes>` for `Style` and `StyleSource` when
+  the `yew_integration` feature is active.
+
 ## v0.10.0
 
 ### Breaking Changes:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a fork of [css-in-rust](https://github.com/lukidoescode/css-in-rust).
 Add the following to your `Cargo.toml`:
 
 ```toml
-stylist = "0.9"
+stylist = "0.10"
 ```
 
 ## Usage

--- a/packages/stylist-core/src/ast/selector.rs
+++ b/packages/stylist-core/src/ast/selector.rs
@@ -27,7 +27,7 @@ impl ToStyleStr for Selector {
             if joined_s.contains('&') || joined_s.contains(":root") {
                 w.push_str(
                     &joined_s
-                        .replace("&", scoped_class.as_str())
+                        .replace('&', scoped_class.as_str())
                         .replace(":root", scoped_class.as_str()),
                 );
             } else {
@@ -43,7 +43,7 @@ impl ToStyleStr for Selector {
 
         // For global styles, if it contains &, it will be replaced with html.
         } else if joined_s.contains('&') {
-            w.push_str(&joined_s.replace("&", ":root"));
+            w.push_str(&joined_s.replace('&', ":root"));
         // For other styles, it will be written as is.
         } else {
             w.push_str(&joined_s);

--- a/packages/stylist/src/yew/mod.rs
+++ b/packages/stylist/src/yew/mod.rs
@@ -115,6 +115,18 @@ impl From<StyleSource<'_>> for Classes {
     }
 }
 
+impl IntoPropValue<Classes> for Style {
+    fn into_prop_value(self) -> Classes {
+        self.into()
+    }
+}
+
+impl IntoPropValue<Classes> for StyleSource<'_> {
+    fn into_prop_value(self) -> Classes {
+        self.into()
+    }
+}
+
 impl IntoPropValue<StyleSource<'static>> for Sheet {
     fn into_prop_value(self) -> StyleSource<'static> {
         self.into()


### PR DESCRIPTION
I think this change is small enough and worth to backport to make it useable asap for users on yew v0.19.

Also fixes a misleading typo in our readme that is currently still [live on crates.io](https://crates.io/crates/stylist) referring to an old version.

I'd be happy to have this released as 0.10.1.

Fixes #74 