### PR TITLE
Prepare Release of v0.11

### DIFF
--- a/examples/benchmarks/src/main.rs
+++ b/examples/benchmarks/src/main.rs
@@ -300,7 +300,7 @@ impl Component for Benchmarks {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum AppMsg {
     Start,
 }

--- a/packages/stylist-core/Cargo.toml
+++ b/packages/stylist-core/Cargo.toml
@@ -29,7 +29,7 @@ once_cell = "1.13.0"
 
 [dev-dependencies]
 log = "0.4.17"
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.31"

--- a/packages/stylist-core/Cargo.toml
+++ b/packages/stylist-core/Cargo.toml
@@ -19,6 +19,7 @@ categories = ["wasm", "web-programming"]
 readme = "README.md"
 homepage = "https://github.com/futursolo/stylist-rs"
 resolver = "2"
+rust-version = "1.60"
 
 [dependencies]
 nom = { version = "7.1.1", optional = true }
@@ -34,4 +35,4 @@ env_logger = "0.9.0"
 wasm-bindgen-test = "0.3.31"
 
 [features]
-parser = ["nom"]
+parser = ["dep:nom"]

--- a/packages/stylist-macros/Cargo.toml
+++ b/packages/stylist-macros/Cargo.toml
@@ -19,6 +19,7 @@ categories = ["wasm", "web-programming"]
 readme = "README.md"
 homepage = "https://github.com/futursolo/stylist-rs"
 resolver = "2"
+rust-version = "1.60"
 
 [lib]
 proc-macro = true

--- a/packages/stylist-macros/Cargo.toml
+++ b/packages/stylist-macros/Cargo.toml
@@ -37,4 +37,4 @@ itertools = "0.10.3"
 log = "0.4.17"
 
 [dev-dependencies]
-env_logger = "0.9.0"
+env_logger = "0.10.0"

--- a/packages/stylist/Cargo.toml
+++ b/packages/stylist/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["wasm", "web-programming"]
 readme = "../../README.md"
 homepage = "https://github.com/futursolo/stylist-rs"
 resolver = "2"
+rust-version = "1.60"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/packages/stylist/Cargo.toml
+++ b/packages/stylist/Cargo.toml
@@ -44,7 +44,7 @@ features = [
 
 [dev-dependencies]
 log = "0.4.17"
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 trybuild = "1.0.63"
 yew = "0.20"
 


### PR DESCRIPTION
- Update MSRV to 1.60 due to namespaced dependency.
- Update dependencies.
- Fix clippy warnings.