### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a fork of [css-in-rust](https://github.com/lukidoescode/css-in-rust).
 Add the following to your `Cargo.toml`:
 
 ```toml
-stylist = "0.10"
+stylist = "0.11"
 ```
 
 ## Usage


### PR DESCRIPTION
Breaking change in 0.11, but the README still showed the old version (0.10)