### PR TITLE
Increase MSRV to 1.64.0

### DIFF
--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -126,7 +126,8 @@ jobs:
     needs:
       - lint
       - rustfmt
-      - test-native
+      - test-native-stable
+      - test-native-msrv
       - test-web
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
     steps:

--- a/.github/workflows/everything.yml
+++ b/.github/workflows/everything.yml
@@ -42,8 +42,8 @@ jobs:
         env:
           RUSTFLAGS: "--cfg releasing"
 
-  test-native:
-    name: Run Native Tests
+  test-native-stable:
+    name: Run Native Tests (Stable)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
@@ -59,6 +59,30 @@ jobs:
 
       - name: Run cargo test
         run: cargo test --all-features --all
+        env:
+          RUSTFLAGS: "--cfg releasing"
+
+  test-native-msrv:
+    name: Run Native Tests (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.64.0
+        with:
+          components: rustfmt, clippy
+
+      - name: Restore Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      # We only run tests on core packages, examples can be upgraded to be incompatible of msrv.
+      - name: Run cargo test
+        run: |
+          cargo test --all-features --package stylist-core
+          cargo test --all-features --package stylist-macros
+          cargo test --all-features --package stylist
         env:
           RUSTFLAGS: "--cfg releasing"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v0.13.0
+
+- Increase MSRV to 1.64.0.
+
 ### v0.12.1
 
 - Implemented a workaround that mitigates the linker error from Rust compiler (https://github.com/rust-lang/rust/issues/111888).

--- a/packages/stylist-core/Cargo.toml
+++ b/packages/stylist-core/Cargo.toml
@@ -9,17 +9,12 @@ authors = [
 ]
 edition = "2021"
 description = "Stylist is a CSS-in-Rust styling solution for WebAssembly Applications."
-keywords = [
-    "CSS",
-    "web",
-    "css-in-rust",
-    "yew"
-]
+keywords = ["CSS", "web", "css-in-rust", "yew"]
 categories = ["wasm", "web-programming"]
 readme = "README.md"
 homepage = "https://github.com/futursolo/stylist-rs"
 resolver = "2"
-rust-version = "1.60"
+rust-version = "1.64.0"
 
 [dependencies]
 nom = { version = "7.1.1", optional = true }

--- a/packages/stylist-core/src/error.rs
+++ b/packages/stylist-core/src/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 //
 // For crates outside of this workspace, `__proc_macro_workaround` will not be enabled
 // when they use version = "2021" or resolver = "2" as procedural macros can have different feature
-// flags. This should be OK for all downstream crates as stylist requires Rust 1.60 which supports
+// flags. This should be OK for all downstream crates as stylist requires Rust 1.64.0 which supports
 // both.
 #[cfg(not(feature = "__proc_macro_workaround"))]
 type JsValue = wasm_bindgen::JsValue;

--- a/packages/stylist-macros/Cargo.toml
+++ b/packages/stylist-macros/Cargo.toml
@@ -9,17 +9,12 @@ authors = [
     "Martin Molzer <ga65guy@mytum.de>",
 ]
 description = "Stylist is a CSS-in-Rust styling solution for WebAssembly Applications."
-keywords = [
-    "CSS",
-    "web",
-    "css-in-rust",
-    "yew"
-]
+keywords = ["CSS", "web", "css-in-rust", "yew"]
 categories = ["wasm", "web-programming"]
 readme = "README.md"
 homepage = "https://github.com/futursolo/stylist-rs"
 resolver = "2"
-rust-version = "1.60"
+rust-version = "1.64.0"
 
 [lib]
 proc-macro = true
@@ -35,10 +30,15 @@ itertools = "0.11.0"
 log = "0.4.17"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-stylist-core = { path = "../stylist-core", version = "0.12", features = ["parser", "__proc_macro_workaround"] }
+stylist-core = { path = "../stylist-core", version = "0.12", features = [
+    "parser",
+    "__proc_macro_workaround",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-stylist-core = { path = "../stylist-core", version = "0.12", features = ["parser"] }
+stylist-core = { path = "../stylist-core", version = "0.12", features = [
+    "parser",
+] }
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/packages/stylist/Cargo.toml
+++ b/packages/stylist/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["wasm", "web-programming"]
 readme = "../../README.md"
 homepage = "https://github.com/futursolo/stylist-rs"
 resolver = "2"
-rust-version = "1.60"
+rust-version = "1.64.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/packages/stylist/Cargo.toml
+++ b/packages/stylist/Cargo.toml
@@ -48,6 +48,7 @@ log = "0.4.17"
 env_logger = "0.10.0"
 trybuild = "1.0.72"
 yew = "0.20"
+rustversion = "1"
 
 [features]
 default = ["debug_style_locations", "debug_parser", "macros", "random"]

--- a/packages/stylist/tests/macro_integration_tests.rs
+++ b/packages/stylist/tests/macro_integration_tests.rs
@@ -1,6 +1,5 @@
 #[allow(dead_code)]
 #[rustversion::attr(stable(1.64.0), test)]
-#[test]
 fn test_macro_integrations() {
     let t = trybuild::TestCases::new();
 

--- a/packages/stylist/tests/macro_integration_tests.rs
+++ b/packages/stylist/tests/macro_integration_tests.rs
@@ -1,3 +1,5 @@
+#[allow(dead_code)]
+#[rustversion::attr(stable(1.64.0), test)]
 #[test]
 fn test_macro_integrations() {
     let t = trybuild::TestCases::new();


### PR DESCRIPTION
This pull request increase the MSRV to 1.64.0. This matches the MSRV of the upcoming Yew v0.21.0.

This pull request also limits macro tests to only run on MSRV.