### PR TITLE
Bump MSRV to 1.66 in Cargo.toml

### DIFF
--- a/packages/stylist-core/Cargo.toml
+++ b/packages/stylist-core/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["wasm", "web-programming"]
 readme = "README.md"
 homepage = "https://github.com/futursolo/stylist-rs"
 resolver = "2"
-rust-version = "1.64.0"
+rust-version = "1.66.0"
 
 [dependencies]
 nom = { version = "7.1.1", optional = true }

--- a/packages/stylist-macros/Cargo.toml
+++ b/packages/stylist-macros/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["wasm", "web-programming"]
 readme = "README.md"
 homepage = "https://github.com/futursolo/stylist-rs"
 resolver = "2"
-rust-version = "1.64.0"
+rust-version = "1.66.0"
 
 [lib]
 proc-macro = true

--- a/packages/stylist/Cargo.toml
+++ b/packages/stylist/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["wasm", "web-programming"]
 readme = "../../README.md"
 homepage = "https://github.com/futursolo/stylist-rs"
 resolver = "2"
-rust-version = "1.64.0"
+rust-version = "1.66.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
This pull request increases rust-version to 1.66 in `Cargo.toml` as that's required to pass now.