### PR TITLE
Try to supports WASI targets.

### DIFF
--- a/examples/yew-ssr/Cargo.toml
+++ b/examples/yew-ssr/Cargo.toml
@@ -19,7 +19,7 @@ console_log = { version = "1.0.0", features = ["color"] }
 yew = { version = "0.21" }
 stylist = { path = "../../packages/stylist", features = ["yew_integration"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(any(not(target_arch = "wasm32"), feature = "wasi"))'.dependencies]
 tokio = { version = "1.22.0", features = ["full"] }
 env_logger = "0.10"
 clap = { version = "4.0.29", features = ["derive"] }

--- a/packages/stylist-core/Cargo.toml
+++ b/packages/stylist-core/Cargo.toml
@@ -27,9 +27,10 @@ serde = { version = "1", features = ["derive"] }
 log = "0.4.17"
 env_logger = "0.10.0"
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(feature = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3.33"
 
 [features]
 parser = ["dep:nom"]
+wasi = []
 __proc_macro_workaround = []

--- a/packages/stylist-macros/Cargo.toml
+++ b/packages/stylist-macros/Cargo.toml
@@ -29,16 +29,19 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 itertools = "0.11.0"
 log = "0.4.17"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(any(not(target_arch = "wasm32"), feature = "wasi"))'.dependencies]
 stylist-core = { path = "../stylist-core", version = "0.13", features = [
     "parser",
     "__proc_macro_workaround",
 ] }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(feature = "wasi")))'.dependencies]
 stylist-core = { path = "../stylist-core", version = "0.13", features = [
     "parser",
 ] }
 
 [dev-dependencies]
 env_logger = "0.10.0"
+
+[features]
+wasi = []

--- a/packages/stylist/Cargo.toml
+++ b/packages/stylist/Cargo.toml
@@ -62,6 +62,7 @@ yew_use_media_query = ["yew", "web-sys/MediaQueryList", "dep:gloo-events"]
 yew_use_style = ["yew"]
 ssr = ["html-escape"]
 hydration = []
+wasi = ["stylist-core/wasi", "stylist-macros?/wasi"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/packages/stylist/src/arch.rs
+++ b/packages/stylist/src/arch.rs
@@ -1,19 +1,19 @@
 use crate::{Error, Result};
 pub use wasm_bindgen::JsValue;
 use web_sys::Window;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "wasi")))]
 use web_sys::{Document, HtmlHeadElement};
 
 pub(crate) fn window() -> Result<Window> {
     web_sys::window().ok_or(Error::Web(None))
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "wasi")))]
 pub(crate) fn document() -> Result<Document> {
     window()?.document().ok_or(Error::Web(None))
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", not(feature = "wasi")))]
 pub(crate) fn doc_head() -> Result<HtmlHeadElement> {
     document()?.head().ok_or(Error::Web(None))
 }

--- a/packages/stylist/src/manager/mod.rs
+++ b/packages/stylist/src/manager/mod.rs
@@ -94,7 +94,7 @@ impl StyleManagerBuilder {
     /// Build the [`StyleManager`].
     #[allow(unused_mut)]
     pub fn build(mut self) -> Result<StyleManager> {
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(all(target_arch = "wasm32", not(feature = "wasi")))]
         if self.container.is_none() {
             use crate::arch::doc_head;
             self.container = Some(doc_head()?.into());
@@ -218,7 +218,7 @@ impl StyleManager {
     }
 
     /// Mount the [`Style`](crate::Style) into the DOM tree.
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", not(feature = "wasi")))]
     pub(crate) fn mount(&self, content: &StyleContent) -> Result<()> {
         use crate::arch::document;
         use crate::Error;
@@ -245,7 +245,7 @@ impl StyleManager {
     }
 
     /// Unmount the [`Style`](crate::Style) from the DOM tree.
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", not(feature = "wasi")))]
     pub(crate) fn unmount(id: &StyleId) -> Result<()> {
         use crate::arch::document;
         use crate::Error;
@@ -264,7 +264,7 @@ impl StyleManager {
     }
 
     /// Mount the [`Style`] in to the DOM tree.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(not(target_arch = "wasm32"), feature = "wasi"))]
     #[allow(unused_variables)]
     pub(crate) fn mount(&self, content: &StyleContent) -> Result<()> {
         // Does nothing on non-wasm targets.
@@ -272,7 +272,7 @@ impl StyleManager {
     }
 
     /// Unmount the [`Style`] from the DOM tree.
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(not(target_arch = "wasm32"), feature = "wasi"))]
     #[allow(unused_variables)]
     pub(crate) fn unmount(id: &StyleId) -> Result<()> {
         // Does nothing on non-wasm targets.


### PR DESCRIPTION
I've been trying to use `yew` to render the page into the static HTML string on WASI. However, `stylist` cannot distinguish the browser WASM target (`wasm32-unknown-unknown` with `wasm-bindgen`) and WASI target (`wasm32-wasi`), and it would choose wrong modules for `wasm32-*`.

I have fixed it by using a feature flag called `wasi`, and it would fix the problem.
