### PR TITLE
Fix non_upper_case_globals lint in some cases

### DIFF
--- a/packages/stylist-macros/src/output/maybe_static.rs
+++ b/packages/stylist-macros/src/output/maybe_static.rs
@@ -26,7 +26,8 @@ where
             .collect();
 
         if inner_ctx.is_const() {
-            let name = Ident::new("items", Span::mixed_site());
+            // Span::mixed_site avoid capture of the variable in user-provided parts of #contents
+            let name = Ident::new("ITEMS", Span::mixed_site());
             let content_len = contents.len();
             quote! {
                 ::std::borrow::Cow::<[#typ]>::Borrowed ({


### PR DESCRIPTION
This was never reported as a bug, but mentioned on the discord, that sometimes the macro emits warnings that can be ignored with `#![allow(non_upper_case_globals)]`. I believe the culprit in the situation is the emitted `const _:` when parts of the style AST can be constructed at compile time.

I've added a small comment on the usage of `Span::mixed_site()` for future reference too, since I had to look that up when editing.